### PR TITLE
git-import-srpm: add script to create source branches from srpm repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ the upstream point where the patch-queue of our SRPM was applied onto.  As
 such, our patch-queue can be found with the range `/pre-base../base`.
 
 The branches are created by the
-[git-import-srpm](https://github.com/xcp-ng/xcp/blob/quentin-git-import-srpm/scripts/git-import-srpm)
-script run from within the SRPM repository.
+[git-import-srpm](./scripts/git-import-srpm) script run from within the
+SRPM repository.
 
 We also have an [elixir instance]() with the source code indexed for all
 past released RPMs.
@@ -200,17 +200,16 @@ rebasing the source code branches:
 
 You should have installed `git-review-rebase` from the [Install the
 git-review-rebase tool chapter](#install-the-git-review-rebase-tool), we'll
-also need `git-import-srpm` which is present in the [main
-xcp](https://www.github.com/xcp-ng/xcp) repository:
-
-```bash
-git clone git@github.com:xcp-ng/xcp.git
-# Lives in scripts/git-import-srpm
-```
+also need `git-import-srpm` which is present in the [scripts](./scripts/)
+directory.
 
 Note that `git-import-srpm` is a simple bash script and doesn't need any
-prior configuration before use, it is present in
-`/path/to/xcp/repo/scripts/git-import-srpm`.
+prior configuration before use, although it does need working `rpmbuild`
+and `rpmspec` tools, which can be installed on Debian derivates with:
+
+```bash
+sudo apt-get install rpm
+```
 
 ## Rebase the kernel to latest upstream
 
@@ -517,7 +516,7 @@ verify that your src RPM will generate the same sources.
 ```bash
 cd /path/to/rpm/repo
 git commit -s -m "kernel: rebase to v4.19.325"
-/path/to/xcp/repo/scripts/git-import-srpm HEAD
+/path/to/hypervisor-dev/repo/scripts/git-import-srpm HEAD
 ```
 
 This should create a new branch, you can then use `git diff
@@ -686,7 +685,7 @@ against our locked list.  If it reports breakage, follow
 ## Verify source RPM generates the same sources
 
 ```bash
-/path/to/xcp/repo/scripts/git-import-srpm HEAD
+/path/to/hypervisor-dev/repo/scripts/git-import-srpm HEAD
 ```
 
 Use `git diff <your-branch> <newly_imported_branch>` to verify there are
@@ -773,11 +772,11 @@ Once built, `check-kabi` will verify the symbol exports and it should not
 fail at this step given XenServer folks guarantee a stable kABI.
 
 Finally, verify that the source RPM can be imported as a source branch
-cleanly using the `git-import-srpm` script:
+cleanly using the [`git-import-srpm`](./scripts/git-import-srpm) script:
 
 ```bash
 git commit -s -m "kernel: incorporate XS <xs-version> changes"
-/path/to/xcp/repo/scripts/git-import-srpm HEAD
+/path/to/hypervisor-dev/repo/scripts/git-import-srpm HEAD
 ```
 
 # Handling kABI breakage

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -128,7 +128,7 @@ function get_branch_name() {
     if [[ -z ${vendor} || -z ${full_version} ]]; then
         echo "unknown_branch_name_for_rev_${revision}"
     else
-        echo "${PRODUCT}/${vendor}-${full_version}/base"
+        echo "${PRODUCT}/${vendor}-${full_version}/patched"
     fi
 
 }
@@ -164,7 +164,7 @@ function init_worktrees() {
     }
 
     git -C "${CODE_REPO_PATH}" worktree add -B "${BRANCH_NAME}-partial" "${code_repo_worktree}" "${base_version}" >> "${COMMAND_LOGS}"
-    git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%base}pre-base" "${base_version}"
+    git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%patched}source" "${base_version}"
 }
 
 # Fix the date in case it is not present in the patch file to get

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -391,7 +391,12 @@ git show "HEAD:${SPEC_FILE}" | while IFS= read -r l; do
             p="${l#* }"
             apply_patch "${CODE_REPO_WORKTREE}" "${SRPM_REPO_WORKTREE}/SOURCES/${p}" >> "${COMMAND_LOGS}" 2>> "${COMMAND_LOGS}" || {
                 echo "[-] [apply_patch] Failed reconstructing ${BRANCH_NAME} for ${SRPM_REPO_REVISION}, check ${COMMAND_LOGS}"
-                exit 1
+                if [[ -z "${CARRY_ON:-}" ]]; then
+                    exit 1
+                else
+                    git am --abort || :
+                    git reset --hard || :
+                fi
             }
             ;;
         *)

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -378,7 +378,7 @@ function import_all_branches() {
     done | (SRPM_REPO_PATH="${SRPM_REPO_PATH}" CODE_REPO_PATH="${CODE_REPO_PATH}" xargs -n 1 -P "${nproc}" "${THIS_SCRIPT}")
 }
 
-COMMAND_LOGS=/tmp/git-import-srpm.${1}.debug.log
+COMMAND_LOGS=/tmp/git-import-srpm.${PRODUCT}.${1}.debug.log
 if [[ -f ${COMMAND_LOGS} ]]; then
     rm "${COMMAND_LOGS}"
 fi

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -473,4 +473,4 @@ wait "${RPMBUILD_PID}" || {
 }
 
 # Workaround `git branch` race condition when it moves the branch reflog.
-flock "${CODE_REPO_PATH}/.git/branch-rename.lock" -c "git -C \"${CODE_REPO_WORKTREE}\" branch -m \"${BRANCH_NAME}-partial\" \"${BRANCH_NAME}\""
+git -C "${CODE_REPO_PATH}" branch -m "${BRANCH_NAME}-partial" "${BRANCH_NAME}"

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -34,6 +34,7 @@ THIS_SCRIPT="$(readlink -f "$0")"
 
 SRPM_REPO_PATH=${SRPM_REPO_PATH:-${PWD}}
 PRODUCT="$(basename "${SRPM_REPO_PATH}/SPECS/"*.spec .spec)"
+OOT_DRIVER_IMPORT=${OOT_DRIVER_IMPORT:-}
 CODE_REPO_PATH="${CODE_REPO_PATH:-${SRPM_REPO_PATH}/../${PRODUCT/kernel/linux}/}"
 SPEC_FILE="SPECS/${PRODUCT}.spec"
 if [[ ${PRODUCT} = "kernel" || ${PRODUCT} = "qemu" ]]; then
@@ -44,8 +45,12 @@ elif [[ ${PRODUCT} = "rpm" ]]; then
     RELEASE_PREFIX="rpm-"
     RELEASE_SUFFIX="-release"
 else
-    echo "Unknown package: '${PRODUCT}'"
-    exit 1
+    if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
+	echo "Unknown package: '${PRODUCT}'"
+	exit 1
+    fi
+    RELEASE_PREFIX=""
+    RELEASE_SUFFIX=""
 fi
 
 GIT_COMMIT_OPTIONS="--no-gpg-sign"
@@ -153,11 +158,16 @@ function init_worktrees() {
     git -C "${SRPM_REPO_PATH}" worktree add --detach "${srpm_repo_worktree}" "${srpm_repo_revision}^0" >> "${COMMAND_LOGS}"
 
     # Upstream stable base
-    base_version=$(get_base_version "${srpm_repo_worktree}" HEAD)
-    if [[ ${PRODUCT} = "xen" ]]; then
-        if [[ ${base_version} = "RELEASE-4.13.0" ]]; then
-            base_version=85e1424de2dda
-        fi
+    local base_version
+    if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
+	base_version=$(get_base_version "${srpm_repo_worktree}" HEAD)
+	if [[ ${PRODUCT} = "xen" ]]; then
+            if [[ ${base_version} = "RELEASE-4.13.0" ]]; then
+		base_version=85e1424de2dda
+            fi
+	fi
+    else
+	base_version=$(git -C "${CODE_REPO_PATH}" rev-parse "origin/source/8.3^{/Initial commit.}")
     fi
 
     BRANCH_NAME="$(get_branch_name "${srpm_repo_worktree}" HEAD)"
@@ -407,26 +417,28 @@ rpmbuild --nodeps \
          -bp "${SRPM_REPO_WORKTREE}/${SPEC_FILE}" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" &
 RPMBUILD_PID=$!
 
-cd "${SRPM_REPO_WORKTREE}"
+if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
+    cd "${SRPM_REPO_WORKTREE}"
 
-git show "HEAD:${SPEC_FILE}" | while IFS= read -r l; do
-    case "${l}" in
-        Patch*)
-            p="${l#* }"
-            apply_patch "${CODE_REPO_WORKTREE}" "${SRPM_REPO_WORKTREE}/SOURCES/${p}" >> "${COMMAND_LOGS}" 2>> "${COMMAND_LOGS}" || {
-                echo "[-] [apply_patch] Failed reconstructing ${BRANCH_NAME} for ${SRPM_REPO_REVISION}, check ${COMMAND_LOGS}"
-                if [[ -z "${CARRY_ON:-}" ]]; then
-                    exit 1
-                else
-                    git am --abort || :
-                    git reset --hard || :
-                fi
-            }
-            ;;
-        *)
-            ;;
-    esac
-done
+    git show "HEAD:${SPEC_FILE}" | while IFS= read -r l; do
+	case "${l}" in
+            Patch*)
+		p="${l#* }"
+		apply_patch "${CODE_REPO_WORKTREE}" "${SRPM_REPO_WORKTREE}/SOURCES/${p}" >> "${COMMAND_LOGS}" 2>> "${COMMAND_LOGS}" || {
+                    echo "[-] [apply_patch] Failed reconstructing ${BRANCH_NAME} for ${SRPM_REPO_REVISION}, check ${COMMAND_LOGS}"
+                    if [[ -z "${CARRY_ON:-}" ]]; then
+			exit 1
+                    else
+			git am --abort || :
+			git reset --hard || :
+                    fi
+		}
+		;;
+            *)
+		;;
+	esac
+    done
+fi
 
 wait "${RPMBUILD_PID}" || {
     echo "[-] [rpmbuild] Failed reconstructing ${BRANCH_NAME} for ${SRPM_REPO_REVISION}, check ${COMMAND_LOGS}"
@@ -435,7 +447,13 @@ wait "${RPMBUILD_PID}" || {
     build_dir="$(get_build_dir "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
     git -C "${CODE_REPO_WORKTREE}" --work-tree "${build_dir}" add -A
     export_author
-    git -C "${CODE_REPO_WORKTREE}" commit ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "rpmbuild: remaining diff." 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" || :
+
+    if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
+	commit_msg="rpmbuild: remaining diff."
+    else
+	commit_msg="git-import-srpm: import of $(get_full_version "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
+    fi
+    git -C "${CODE_REPO_WORKTREE}" commit ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "${commit_msg}" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" || :
 }
 
 # Workaround `git branch` race condition when it moves the branch reflog.

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -40,6 +40,9 @@ if [[ ${PRODUCT} = "kernel" || ${PRODUCT} = "qemu" ]]; then
     RELEASE_PREFIX="v"
 elif [[ ${PRODUCT} = "xen" ]]; then
     RELEASE_PREFIX="RELEASE-"
+elif [[ ${PRODUCT} = "rpm" ]]; then
+    RELEASE_PREFIX="rpm-"
+    RELEASE_SUFFIX="-release"
 else
     echo "Unknown package: '${PRODUCT}'"
     exit 1
@@ -77,7 +80,7 @@ function get_base_version() {
 
     check_spec_file "${worktree}" "${revision}"
 
-    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | rpmspec -P /dev/stdin | awk "/^Version:/{print \"${RELEASE_PREFIX}\" \$NF}"
+    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | rpmspec -P /dev/stdin | awk "/^Version:/{print \"${RELEASE_PREFIX}\" \$NF \"${RELEASE_SUFFIX:-}\"}"
 }
 
 function get_release() {
@@ -93,7 +96,10 @@ function get_full_version() {
     local base_version="$1"
     local release="$2"
 
-    echo "${base_version#"${RELEASE_PREFIX}"}-${release}"
+    local raw_version="${base_version#"${RELEASE_PREFIX}"}"
+    raw_version="${raw_version%"${RELEASE_SUFFIX:-}"}"
+
+    echo "${raw_version}-${release}"
 }
 
 function get_vendor() {

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -119,8 +119,14 @@ function get_release() {
 }
 
 function get_full_version() {
-    local base_version="$1"
-    local release="$2"
+    local worktree="$1"
+    local revision="$2"
+
+    local base_version
+    base_version=$(get_base_version "${worktree}" "${revision}")
+
+    local release
+    release="$(get_release "${worktree}" "${revision}")"
 
     local raw_version="${base_version#"${RELEASE_PREFIX}"}"
     raw_version="${raw_version%"${RELEASE_SUFFIX:-}"}"
@@ -143,13 +149,10 @@ function get_branch_name() {
     local worktree="$1"
     local revision="$2"
 
-    base_version=$(get_base_version "${worktree}" "${revision}")
-
-    release="$(get_release "${worktree}" "${revision}")"
-
+    local vendor
     vendor=$(get_vendor "${worktree}" "${revision}")
 
-    full_version="$(get_full_version "${base_version}" "${release}")"
+    full_version="$(get_full_version "${worktree}" "${revision}")"
 
     if [[ -z ${vendor} || -z ${full_version} ]]; then
         echo "unknown_branch_name_for_rev_${revision} vendor=${vendor:-} full_version=${full_version:-}"

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -1,0 +1,406 @@
+#!/bin/bash -eu
+#
+# tl;dr:
+# - To import a specific revision, provided you're in the srpm repo:
+#     git-import-srpm HEAD
+#
+# - To import all revisions (the script will dedupe the branches):
+#     git-import-srpm --all
+#
+# This is a poor man's script importing a SRPM into a git repository.  It
+# has a few limitations in its current quick&dirty implementation:
+#
+# - All changes made during the %prep step are squashed into one commit at
+# the end of the import.
+#
+# - Loses any comments appended to patches in the spec file, these could be
+# added to the commit description.
+#
+# On Debian derivatives, you'll need:
+#  sudo apt-get install rpm
+#
+# Simply run it inside a SRPM git repository and give it a revision (can be
+# tag, branch, sha1, ...), e.g.:
+#
+#  CODE_REPO_PATH=/path/to/linux/repo SRPM_REPO_PATH=/path/kernel/srpm/repo git-import-srpm XS-8.2.1
+#
+# By default, the SRPM_REPO_PATH is the current working directory.  If no
+# CODE_REPO_PATH is given, a default path is inferred that is
+# SRPM_REPO_PATH/../(linux|xen|qemu) (depending on the product).
+
+set -o pipefail
+
+THIS_SCRIPT="$(readlink -f "$0")"
+
+SRPM_REPO_PATH=${SRPM_REPO_PATH:-${PWD}}
+PRODUCT="$(basename "${SRPM_REPO_PATH}/SPECS/"*.spec .spec)"
+CODE_REPO_PATH="${CODE_REPO_PATH:-${SRPM_REPO_PATH}/../${PRODUCT/kernel/linux}/}"
+SPEC_FILE="SPECS/${PRODUCT}.spec"
+if [[ ${PRODUCT} = "kernel" || ${PRODUCT} = "qemu" ]]; then
+    RELEASE_PREFIX="v"
+elif [[ ${PRODUCT} = "xen" ]]; then
+    RELEASE_PREFIX="RELEASE-"
+else
+    echo "Unknown package: '${PRODUCT}'"
+    exit 1
+fi
+
+GIT_COMMIT_OPTIONS="--no-gpg-sign"
+
+function check_spec_file() {
+    local worktree="$1"
+    local revision="$2"
+    local spec_file
+
+    spec_file="$(git -C "${worktree}" ls-tree --name-only "${revision}" SPECS/)"
+
+    if [[ ${spec_file} != "${SPEC_FILE}" ]]; then
+        echo "${SPEC_FILE} does not exist in ${worktree}:${revision}" 1>&2
+        exit 1
+    fi
+}
+
+function get_build_dir() {
+    local worktree="$1"
+    local revision="$2"
+
+    check_spec_file "${worktree}" "${revision}"
+
+    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
+        rpmspec --query --define "_topdir ${worktree}" --qf '%{name}-%{version}\n' /dev/stdin | \
+        awk 'NR == 1'
+}
+
+function get_base_version() {
+    local worktree="$1"
+    local revision="$2"
+
+    check_spec_file "${worktree}" "${revision}"
+
+    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | rpmspec -P /dev/stdin | awk "/^Version:/{print \"${RELEASE_PREFIX}\" \$NF}"
+}
+
+function get_release() {
+    local worktree="$1"
+    local revision="$2"
+
+    check_spec_file "${worktree}" "${revision}"
+
+    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | rpmspec -P /dev/stdin | awk '/^Release:/{print $NF}'
+}
+
+function get_full_version() {
+    local base_version="$1"
+    local release="$2"
+
+    echo "${base_version#"${RELEASE_PREFIX}"}-${release}"
+}
+
+function get_vendor() {
+    local worktree="$1"
+    local revision="$2"
+
+    check_spec_file "${worktree}" "${revision}"
+
+    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | grep -c -e XCP-ng -e xcp > /dev/null \
+        && echo "xcpng" \
+        || echo "xenserver"
+}
+
+function get_branch_name() {
+    local worktree="$1"
+    local revision="$2"
+
+    base_version=$(get_base_version "${worktree}" "${revision}")
+
+    release="$(get_release "${worktree}" "${revision}")"
+
+    vendor=$(get_vendor "${worktree}" "${revision}")
+
+    full_version="$(get_full_version "${base_version}" "${release}")"
+
+    if [[ -z ${vendor} || -z ${full_version} ]]; then
+        echo "unknown_branch_name_for_rev_${revision}"
+    else
+        echo "${PRODUCT}/${vendor}-${full_version}/base"
+    fi
+
+}
+
+function init_worktrees() {
+    local srpm_repo_worktree="$1"
+    local code_repo_worktree="$2"
+    local srpm_repo_revision="$3"
+
+    git -C "${SRPM_REPO_PATH}" worktree add --detach "${srpm_repo_worktree}" "${srpm_repo_revision}^0" >> "${COMMAND_LOGS}"
+
+    # Upstream stable base
+    base_version=$(get_base_version "${srpm_repo_worktree}" HEAD)
+    if [[ ${PRODUCT} = "xen" ]]; then
+        if [[ ${base_version} = "RELEASE-4.13.0" ]]; then
+            base_version=85e1424de2dda
+        fi
+    fi
+
+    BRANCH_NAME="$(get_branch_name "${srpm_repo_worktree}" HEAD)"
+
+    echo "[+] Constructing ${BRANCH_NAME} from rev ${srpm_repo_revision}"
+
+    if git -C "${CODE_REPO_PATH}" show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+        echo "[-] branch ${BRANCH_NAME} already exists"
+        exit 1
+    fi
+
+
+    git -C "${CODE_REPO_PATH}" rev-parse "${base_version}" 2> /dev/null > /dev/null || {
+        echo "- ${BRANCH_NAME}: ${base_version} cannot be found, have you fetched"
+        exit 1
+    }
+
+    git -C "${CODE_REPO_PATH}" worktree add -B "${BRANCH_NAME}-partial" "${code_repo_worktree}" "${base_version}" >> "${COMMAND_LOGS}"
+    git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%base}pre-base" "${base_version}"
+}
+
+# Fix the date in case it is not present in the patch file to get
+# idempotent runs.
+function fixup_date() {
+    local p="${1}"
+
+    author_date="Sat Sep 19 2015 06:09:42 GMT+0000"
+
+    awk '
+BEGIN { has_date=0 }
+/^Date:/ { has_date=1 }
+{ lines[NR]=$0 }
+END {
+  if (!has_date) {
+    for (i=1; i<=NR; i++) {
+      print lines[i]
+      if (lines[i] ~ /^From:/) {
+        print "Date: '"${author_date}"'"
+      }
+    }
+  } else {
+    for (i=1; i<=NR; i++) print lines[i]
+  }
+}
+' "${p}" > "${p}.fixed"
+    mv "${p}.fixed" "${p}"
+
+}
+
+function load_author_and_title() {
+    local p="${1}"
+    local git_dir="${2}"
+
+    mailinfo="$(git mailinfo /dev/null /dev/null < "${p}" |   \
+        sed -n -e 's/^Author: \(.*\)$/export GIT_AUTHOR_NAME=\"\1\"/p'               \
+               -e 's/^Email: \(.*\)$/export GIT_AUTHOR_EMAIL=\"\1\"/p'               \
+               -e 's/^Subject: \(.*\)$/local subject=\"\1\"/p')"
+    eval "${mailinfo}"
+    if [[ -n ${subject:-} ]]; then
+        sed -i "1i\${subject}\n\n" "${git_dir}"/rebase-apply/msg
+    fi
+}
+
+function export_author() {
+    export GIT_COMMITTER_NAME="Vates Git Importer"
+    export GIT_COMMITTER_EMAIL="gitimporter@vates.tech"
+    export GIT_COMMITTER_DATE="1519512702"
+
+    # These are simply default values in case the information is not
+    # present inside the patch file - it allows idempotent runs as well.
+    export GIT_AUTHOR_NAME="${GIT_COMMITTER_NAME}"
+    export GIT_AUTHOR_EMAIL="${GIT_COMMITTER_EMAIL}"
+}
+
+function apply_patch() {
+    local worktree="$1"
+    local patch="$2"
+
+    cd "${worktree}"
+
+    # Quirk to get idempotent runs and properly stitched history in Xen
+    # sources.  This patch creates a .gitarchive-info-pq file with a sha1
+    # to the head of the patch-qeueu, as such it is different every time
+    # and causes history to diverge early in similar branches.  Simply do
+    # not apply it.
+    if [[ $(basename "${p}") = "changeset-info.patch" ]] ; then
+        return 0
+    fi
+
+    export_author
+
+    fixup_date "${patch}"
+
+    local git_dir
+    git_dir=$(git rev-parse --git-dir)
+    if ! git am ${GIT_COMMIT_OPTIONS} -3 < "${patch}"; then
+
+        local unmerged_files
+        unmerged_files="$(git status -s | grep '^UU')"
+        local changes
+        changes="$(git status -s)"
+
+        if [[ -n ${unmerged_files} || -z ${changes} ]]; then
+            # The patch didn't apply.  Sometimes git am is a bit more
+            # peculiar than a patch command, especially if there are index
+            # information it doesn't have in its tree.  In that case
+            # fallback to patch.
+            git reset --hard
+            patch -p1 --fuzz=2 < "${patch}" || return 1
+            git add -A
+            # An error for this git am falls through, likely caused by
+            # missing author information, so we'll use git commit directly
+            # below.
+            if git am ${GIT_COMMIT_OPTIONS} --continue; then
+                return 0
+            fi
+        fi
+
+        # This one is used when we fallback to plain git commit
+        export GIT_AUTHOR_DATE="1442642982"
+        if [[ -s ${git_dir}/rebase-apply/msg ]]; then
+
+            load_author_and_title "${patch}" "${git_dir}"
+
+            if [[ $(basename "${p}") = "qemu-4.2.1-CVE-2023-3354.backport.patch" ]]; then
+                # Patch is malformed
+                sed -i '1i\io: remove io watch if TLS channel is closed during handshake\n' "${git_dir}"/rebase-apply/msg
+                export GIT_AUTHOR_NAME="Daniel P. Berrangé"
+                export GIT_AUTHOR_EMAIL="<berrange@redhat.com>"
+            fi
+
+            # There was a commit description, so try and use it
+            git commit ${GIT_COMMIT_OPTIONS} -F "${git_dir}"/rebase-apply/msg && git am --skip
+        else
+            # No commit description, use the patch path
+            git commit ${GIT_COMMIT_OPTIONS} -m "$(basename "${p}")" && git am --skip
+        fi
+        return $?
+    fi
+    return 0
+}
+
+function apply_spec_quirks() {
+    # This one is no-where to be found, and it doesn't really change any
+    # source code, simply stuff a binary tarball in the sources
+    sed -i "s@cp /usr/src/ipxe-source.tar.gz.*@@" "${SRPM_REPO_WORKTREE}/${SPEC_FILE}"
+
+    # This is a remote source which is not available anymore, so rpmbuild
+    # would fail
+    awk '
+    /^Source[0-9]:/{
+        if ($2 == "https://repo.citrite.net/list/ctx-local-contrib/citrix/branding/Citrix_Logo_Black.png") {
+           sub(/:/, "", $1)
+           source_logo=toupper($1)
+        }
+    }
+    source_logo && $0 ~ source_logo {
+        next
+    }
+    {print}
+' "${SRPM_REPO_WORKTREE}/${SPEC_FILE}" > "${SRPM_REPO_WORKTREE}/${SPEC_FILE}.fixed"
+    mv "${SRPM_REPO_WORKTREE}/${SPEC_FILE}.fixed" "${SRPM_REPO_WORKTREE}/${SPEC_FILE}"
+}
+
+function import_all_branches() {
+    local -A revs_for_version
+    local nproc
+    nproc=$(nproc)
+
+    echo "[+] Gathering unique branches"
+
+    cd "${SRPM_REPO_PATH}"
+
+    for revision in $(git rev-list --min-parents=1 --topo-order HEAD); do
+        local branch_name
+        branch_name="$(get_branch_name "${PWD}" "${revision}")"
+        if [[ -z ${revs_for_version[${branch_name}]:-} ]]; then
+            revs_for_version[${branch_name}]="${revision}"
+        fi
+    done
+
+    for b in "${!revs_for_version[@]}"; do
+        local revision="${revs_for_version[${b}]}"
+        case ${b} in
+            unknown_branch_name*)
+                echo "Could not infer a branch name for revision: ${revision}" 1>&2
+                ;;
+            *)
+                echo "${revs_for_version[${b}]}"
+                ;;
+        esac
+    done | (SRPM_REPO_PATH="${SRPM_REPO_PATH}" CODE_REPO_PATH="${CODE_REPO_PATH}" xargs -n 1 -P "${nproc}" "${THIS_SCRIPT}")
+}
+
+COMMAND_LOGS=/tmp/git-import-srpm.${1}.debug.log
+if [[ -f ${COMMAND_LOGS} ]]; then
+    rm "${COMMAND_LOGS}"
+fi
+exec 2> "${COMMAND_LOGS}"
+
+if [[ "$1" = "--all" ]]; then
+    import_all_branches
+    exit 0
+fi
+
+SRPM_REPO_REVISION=$1
+
+TMPDIR=$(mktemp -d -t src-import-xen-XXX)
+if [[ -z ${DONT_DELETE_TMP_DIR:-} ]]; then
+    trap '
+rm -Rf ${TMPDIR:-/a/path/that/does/not/exist}
+cd ${CODE_REPO_PATH}
+git worktree prune
+cd ${SRPM_REPO_PATH}
+git worktree prune
+' EXIT
+fi
+
+SRPM_REPO_WORKTREE="${TMPDIR}/srpm"
+CODE_REPO_WORKTREE="${TMPDIR}/code"
+
+init_worktrees "${SRPM_REPO_WORKTREE}" "${CODE_REPO_WORKTREE}" "${SRPM_REPO_REVISION}"
+
+apply_spec_quirks
+
+# Newer rpmbuild use a default --fuzz=0 to the patch command, when packages
+# built on older version of rpmbuild would apply it with --fuzz=2, so make
+# sure to use --fuzz=2 here.
+rpmbuild --nodeps \
+         --define "_buildshell /bin/bash" \
+         --define "_topdir ${SRPM_REPO_WORKTREE}" \
+         --define "_default_patch_fuzz 2" \
+         --eval "%{_default_patch_fuzz}" \
+         -bp "${SRPM_REPO_WORKTREE}/${SPEC_FILE}" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" &
+RPMBUILD_PID=$!
+
+cd "${SRPM_REPO_WORKTREE}"
+
+git show "HEAD:${SPEC_FILE}" | while IFS= read -r l; do
+    case "${l}" in
+        Patch*)
+            p="${l#* }"
+            apply_patch "${CODE_REPO_WORKTREE}" "${SRPM_REPO_WORKTREE}/SOURCES/${p}" >> "${COMMAND_LOGS}" 2>> "${COMMAND_LOGS}" || {
+                echo "[-] [apply_patch] Failed reconstructing ${BRANCH_NAME} for ${SRPM_REPO_REVISION}, check ${COMMAND_LOGS}"
+                exit 1
+            }
+            ;;
+        *)
+            ;;
+    esac
+done
+
+wait "${RPMBUILD_PID}" || {
+    echo "[-] [rpmbuild] Failed reconstructing ${BRANCH_NAME} for ${SRPM_REPO_REVISION}, check ${COMMAND_LOGS}"
+    exit 1
+} && {
+    build_dir="$(get_build_dir "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
+    git -C "${CODE_REPO_WORKTREE}" --work-tree "${SRPM_REPO_WORKTREE}/BUILD/${build_dir}" add -A
+    export_author
+    git -C "${CODE_REPO_WORKTREE}" commit ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "rpmbuild: remaining diff." 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" || :
+}
+
+# Workaround `git branch` race condition when it moves the branch reflog.
+flock "${CODE_REPO_PATH}/.git/branch-rename.lock" -c "git -C \"${CODE_REPO_WORKTREE}\" branch -m \"${BRANCH_NAME}-partial\" \"${BRANCH_NAME}\""

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -176,7 +176,11 @@ function init_worktrees() {
 
     if git -C "${CODE_REPO_PATH}" show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
         echo "[-] branch ${BRANCH_NAME} already exists"
-        exit 1
+	if [[ "${FORCE_IMPORT:-}" ]]; then
+	    git branch -D "${BRANCH_NAME}"
+	else
+            exit 1
+	fi
     fi
 
 

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -356,6 +356,7 @@ SRPM_REPO_REVISION=$1
 TMPDIR=$(mktemp -d -t src-import-xen-XXX)
 if [[ -z ${DONT_DELETE_TMP_DIR:-} ]]; then
     trap '
+test "${RPMBUILD_PID:-}" && kill ${RPMBUILD_PID} || :
 rm -Rf ${TMPDIR:-/a/path/that/does/not/exist}
 cd ${CODE_REPO_PATH}
 git worktree prune

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -126,7 +126,7 @@ function get_branch_name() {
     full_version="$(get_full_version "${base_version}" "${release}")"
 
     if [[ -z ${vendor} || -z ${full_version} ]]; then
-        echo "unknown_branch_name_for_rev_${revision}"
+        echo "unknown_branch_name_for_rev_${revision} vendor=${vendor:-} full_version=${full_version:-}"
     else
         echo "${PRODUCT}/${vendor}-${full_version}/patched"
     fi

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -69,9 +69,21 @@ function get_build_dir() {
 
     check_spec_file "${worktree}" "${revision}"
 
-    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
-        rpmspec --query --define "_topdir ${worktree}" --qf '%{name}-%{version}\n' /dev/stdin | \
-        awk 'NR == 1'
+    local build_dirname=$(git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
+		   rpmspec --query --define "_topdir ${worktree}" --qf '%{name}-%{version}\n' /dev/stdin | \
+		   awk 'NR == 1'
+	    )
+    local build_dir="${worktree}/BUILD/${build_dirname}"
+    if [[ ! -d "${build_dir}" ]] ; then
+	# rpmbuild version 6.x are building in a sub-directory
+        build_dir="${worktree}/BUILD/${build_dirname}-build/${build_dirname}"
+    fi
+
+    if [[ ! -d "${build_dir}" ]]; then
+	echo "Could not infer an existing build directory"
+	exit 1
+    fi
+    echo "${build_dir}"
 }
 
 function get_base_version() {
@@ -409,7 +421,7 @@ wait "${RPMBUILD_PID}" || {
     exit 1
 } && {
     build_dir="$(get_build_dir "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
-    git -C "${CODE_REPO_WORKTREE}" --work-tree "${SRPM_REPO_WORKTREE}/BUILD/${build_dir}" add -A
+    git -C "${CODE_REPO_WORKTREE}" --work-tree "${build_dir}" add -A
     export_author
     git -C "${CODE_REPO_WORKTREE}" commit ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "rpmbuild: remaining diff." 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" || :
 }

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -366,16 +366,28 @@ fi
 SRPM_REPO_REVISION=$1
 
 TMPDIR=$(mktemp -d -t src-import-xen-XXX)
-if [[ -z ${DONT_DELETE_TMP_DIR:-} ]]; then
-    trap '
-test "${RPMBUILD_PID:-}" && kill ${RPMBUILD_PID} || :
-rm -Rf ${TMPDIR:-/a/path/that/does/not/exist}
-cd ${CODE_REPO_PATH}
-git worktree prune
-cd ${SRPM_REPO_PATH}
-git worktree prune
-' EXIT
+trap 'LAST_LINE=$LINENO' DEBUG
+# shellcheck disable=SC2154 # shellcheck is confused and think exit_code is used without being assigned
+trap '
+exit_code=$?
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "Error at line:${LAST_LINE} '\''${BASH_COMMAND}'\'' exited with code ${exit_code}"
+    echo "  Log file: ${COMMAND_LOGS}"
+    if [[ -z "${DONT_DELETE_TMP_DIR:-}" ]]; then
+        echo "  You can re-run the script with DONT_DELETE_TMP_DIR=y to look around in the temporary worktree."
+    else
+        echo "  Temporary worktrees at: ${TMPDIR}"
+    fi
 fi
+if [[ -z "${DONT_DELETE_TMP_DIR:-}" ]]; then
+    test "${RPMBUILD_PID:-}" && kill ${RPMBUILD_PID} || :
+    rm -Rf ${TMPDIR:-/a/path/that/does/not/exist}
+    cd ${CODE_REPO_PATH}
+    git worktree prune
+    cd ${SRPM_REPO_PATH}
+    git worktree prune
+fi
+' EXIT
 
 SRPM_REPO_WORKTREE="${TMPDIR}/srpm"
 CODE_REPO_WORKTREE="${TMPDIR}/code"

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -74,18 +74,27 @@ function get_build_dir() {
 
     check_spec_file "${worktree}" "${revision}"
 
-    local build_dirname=$(git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
-		   rpmspec --query --define "_topdir ${worktree}" --qf '%{name}-%{version}\n' /dev/stdin | \
-		   awk 'NR == 1'
-	    )
-    local build_dir="${worktree}/BUILD/${build_dirname}"
+    local build_dirname_query_filter
+    build_dirname_query_filter='%{name}-%{version}\n'
+    if [[ $(git -C "${worktree}" show "${revision}:${SPEC_FILE}" | grep '^%autosetup' ) =~ [[:space:]]-n[[:space:]]+([^[:space:]]+) ]]; then
+	build_dirname_query_filter="${BASH_REMATCH[1]}"
+    fi
+
+    local build_dirname
+    build_dirname=$(git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
+			rpmspec --query --define "_topdir ${worktree}" --qf "${build_dirname_query_filter}" /dev/stdin | \
+			awk 'NR == 1'
+		 )
+
+    local build_dir
+    build_dir="${worktree}/BUILD/${build_dirname}"
     if [[ ! -d "${build_dir}" ]] ; then
 	# rpmbuild version 6.x are building in a sub-directory
         build_dir="${worktree}/BUILD/${build_dirname}-build/${build_dirname}"
     fi
 
     if [[ ! -d "${build_dir}" ]]; then
-	echo "Could not infer an existing build directory"
+	echo "Could not infer an existing build directory from ${build_dirname}" 1>&2
 	exit 1
     fi
     echo "${build_dir}"


### PR DESCRIPTION
On Debian derivatives, you'll need:
  sudo apt-get install rpm

Simply run it inside a SRPM git repository and give it a revision (can be tag, branch, sha1, ...), e.g.:

```bash
CODE_REPO_PATH=/path/to/linux/repo SRPM_REPO_PATH=/path/kernel/srpm/repo git-import-srpm XS-8.2.1
```

To import all releases as branches, just pass --all:

```bash
git-import-srpm --all
```

By default, the `SRPM_REPO_PATH` is the current working directory. If no `CODE_REPO_PATH` is given, a default path is inferred that is `${SRPM_REPO_PATH}/../(linux|xen|qemu)` (depending on the package being imported).

The script was used import all branches of qemu, xen and the Linux kernel released in current and prior XCP versions, e.g.:

- xen branch example: https://github.com/xcp-ng/xen/tree/xen/xcpng-4.17.5-23.1/base
- qemu branch example: https://github.com/xcp-ng/qemu-dp/tree/qemu/xcpng-4.2.1-5.2.15.2/base
- linux branch example: https://github.com/xcp-ng/linux/tree/linux/xcpng-4.19.19-8.0.32.1/base

The script gives idempotent runs, reconstructed git sha1 will stay the same across runs for a given srpm revision. The script will not touch any of your repository worktrees or indexes, so it is safe to run any time even if you are working in the source repo (patches are applied separately in a temporary worktree).

Note that for each srpm revision, the script will create two branches in the source repository, in the form:

<product>/(xcpng|xenserver)-<version>/(pre-base|base)

The pre-base ref will point to the upstream commit that was used as basis by the source RPM before applying patches. Effectively, the patch-set applied by a source rpm can be rev-listed with `git log /pre-base../base` which allows see-ing how the patchset evolved over time.

You can use `git-review-rebase` easily on two imports to see the changes in the patch-queues.

Original pull-request was on the
[xcp](https://github.com/xcp-ng/xcp/pull/781) repository but after discussion with the OS&Platform team, it was agreed it is better to have it here.  Sub-sequent work could try and add github workflows to run this script automatically when we notice new SRPMs from XenServer, but right now it is a manual process (so is running [import_srpm.py](https://github.com/xcp-ng/xcp/blob/master/scripts/import_srpm.py)).