### PR TITLE
git-review-rebase: loosen hunk pattern regexp.

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/diff_parser.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/diff_parser.py
@@ -18,7 +18,7 @@ class DiffPosition:
 
 
 class DiffParser:
-    hunk_pattern = re.compile(r"@@ -(?P<old_start>\d+),\d+ \+(?P<new_start>\d+),\d+ @@.*")
+    hunk_pattern = re.compile(r"@@ -(?P<old_start>\d+)(,\d+)? \+(?P<new_start>\d+)(,\d+)? @@.*")
 
     def __init__(self):
         self.last_line: None | str = None


### PR DESCRIPTION
Some hunk patterns only add/remove one line and as such do not have an index for the end.  Mark those as optional to avoid a runtime error:

  RuntimeError: "@@ -0,0 +1 @@" does not match hunk header regexp