### PR TITLE
git-review-rebase: add a no-upstream-patchid option to speed-up far rebases.

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/app.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/app.py
@@ -132,6 +132,7 @@ class GitReviewRebase(App):
         )
         self.left_range = await asyncio.to_thread(
             BranchRange,
+            self.args,
             self.repo,
             self.args.left_range.split("..")[0],
             self.args.left_range.split("..")[1],
@@ -139,6 +140,7 @@ class GitReviewRebase(App):
         )
         self.right_range = await asyncio.to_thread(
             BranchRange,
+            self.args,
             self.repo,
             self.args.right_range.split("..")[0],
             self.args.right_range.split("..")[1],

--- a/scripts/git-review-rebase/src/git_review_rebase/branch_range.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/branch_range.py
@@ -1,5 +1,6 @@
 """Branch range representation for git operations."""
 
+import argparse
 from collections import OrderedDict
 
 import pygit2
@@ -13,6 +14,7 @@ class BranchRange:
 
     def __init__(
         self,
+        args: argparse.Namespace,
         repo: pygit2.Repository,
         start_range: str,
         end_range: str,
@@ -20,6 +22,7 @@ class BranchRange:
         merge_base: None | pygit2.Oid = None,
     ) -> None:
         """Initialize a BranchRange."""
+        self.args = args
         self.start_range = start_range
         self.start_range_oid = oid(repo, self.start_range)
         self.end_range = end_range
@@ -59,12 +62,15 @@ class BranchRange:
             if not passed_upstream:
                 self._rebased_commits[commit.id] = commit
 
+        commit_worklist = list(
+            self._commit_by_oid.keys()
+            if self.args.upstream_patchid_lookup
+            else self._rebased_commits.keys()
+        )
         self._commit_by_patchid.update(
             {
                 pygit2.Oid(hex=k): self._get_commit(v)
-                for k, v in patchids(
-                    self._repo, list(self._commit_by_oid.keys()), self._cache_flags
-                ).items()
+                for k, v in patchids(self._repo, commit_worklist, self._cache_flags).items()
             }
         )
         for k, v in self._commit_by_patchid.items():

--- a/scripts/git-review-rebase/src/git_review_rebase/cli.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/cli.py
@@ -24,6 +24,13 @@ def parse_args() -> argparse.Namespace:
         dest="cache",
         help="Disable patchid caching",
     )
+    parser.add_argument(
+        "--no-upstream-patchid",
+        dest="upstream_patchid_lookup",
+        action="store_false",
+        default=True,
+        help="Do not perform patch-id calculation for ancestors of the right range.",
+    )
     parser.add_argument("left_range", help="Left range in format: base..branch")
     parser.add_argument("right_range", help="Right range in format: base..branch")
     args = parser.parse_args()


### PR DESCRIPTION
Corentin rebased a patch-queue from a v6.6.98 kernel to a v6.12.74, that's about 110K commits to calculate patch-ids for when most will be unused.

It's still useful to be able to use git-review-rebase in those cases and rely on loose matching, i.e. just the commit title, so that there is no wait time of over 10 minutes to calculate them all (even if they are cached for later runs).