### PR TITLE
git-review-rebase: allow to filter commits by paths.

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/branch_range.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/branch_range.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import pygit2
 
 from .constants import CacheFlags
-from .git_utils import commit_title, is_ancestor, oid, patchids, range_log
+from .git_utils import commit_title, commit_touches_paths, is_ancestor, oid, patchids, range_log
 
 
 class BranchRange:
@@ -55,10 +55,14 @@ class BranchRange:
         for commit in range_log(
             self._repo, self.merge_base or self.start_range_oid, oid(self._repo, self.end_range)
         ):
-            self._commit_by_title[commit_title(commit)] = commit
-            self._commit_by_oid[commit.id] = commit
             if self.merge_base is not None and commit.id == self.start_range_oid:
                 passed_upstream = True
+
+            if not commit_touches_paths(commit, self.args.paths):
+                continue
+
+            self._commit_by_title[commit_title(commit)] = commit
+            self._commit_by_oid[commit.id] = commit
             if not passed_upstream:
                 self._rebased_commits[commit.id] = commit
 

--- a/scripts/git-review-rebase/src/git_review_rebase/cli.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/cli.py
@@ -33,6 +33,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("left_range", help="Left range in format: base..branch")
     parser.add_argument("right_range", help="Right range in format: base..branch")
+    parser.add_argument(
+        "paths", nargs="*", metavar="PATH", help="Limit to commits touching these paths"
+    )
     args = parser.parse_args()
 
     args.repository = os.path.expanduser(args.repository)

--- a/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
@@ -98,3 +98,18 @@ def patchids(
 
 def abbrev(oid: pygit2.Oid):
     return str(oid)[:12]
+
+
+def commit_touches_paths(commit: pygit2.Commit, paths: list[str]) -> bool:
+    """Return True if the commit modifies any file under the given paths."""
+    if not paths:
+        return True
+    if not commit.parents:
+        diff = commit.tree.diff_to_tree()
+    else:
+        diff = commit.parents[0].tree.diff_to_tree(commit.tree)
+    for delta in diff.deltas:
+        for path in paths:
+            if delta.new_file.path.startswith(path) or delta.old_file.path.startswith(path):
+                return True
+    return False


### PR DESCRIPTION
This commit adds optional path filters a-la `git log -- [path_filters...]`, but a simpler form, just straight matches over complex globbing for now.

This allows to compare completely different branches on rather big repositories (linux kernel, xen), only in a specific sub-directories.  For example, to compare the patches related to microcode loading in XCP-ng Xen versus upstream:

```bash
git-review-rebase 4.17.0-rc4..xen/xcpng-4.17.6-4.1/base 4.17.0-rc4..RELEASE-4.21.1 -- xen/arch/x86/cpu/microcode
```

And it is now easy to see which commits have been backported from 4.21.1 onto the XCP-ng branch and which had conflicts and which are missing.

Super useful in order to check if upstream fixed a commit in a sub-system where we are investigating a bug-report, or if the problem could have been introduced by an incorrect backport.