### PR TITLE
Fix link to experimental Elixir instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The branches are created by the
 [git-import-srpm](./scripts/git-import-srpm) script run from within the
 SRPM repository.
 
-We also have an [elixir instance]() with the source code indexed for all
+We also have an [elixir instance](http://10.1.9.1/) with the source code indexed for all
 past released RPMs.
 
 # Pre-requisites


### PR DESCRIPTION
The link was empty likely on purpose while we wait for the real deployment, as outsiders won't have access to it anyway,
but it was useful for me to not search for the internal card to find the link.
You take it, or you don't and maybe remove the link altogether for now?