### PR TITLE
git-review-rebase: propose to diff with cherry-picked from commits for newly added commits

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/app.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/app.py
@@ -14,7 +14,7 @@ from .constants import CommitMatchInfoFlag, FilterType
 from .git_utils import oid
 from .ui.diff_table import CloseDiffTable, DiffTable
 from .ui.filter_screen import FilterScreen
-from .ui.rebase_table import RebaseTable
+from .ui.rebase_table import RebaseTable, ShowDiff
 
 
 class GitReviewRebase(App):
@@ -178,6 +178,9 @@ class GitReviewRebase(App):
             assert isinstance(event.row_key.value, pygit2.Oid)
             match = self.rebased_commits_matches.commit_matches[event.row_key.value]
             await self._open_diff(match.left_commit, match.right_commit)
+
+    async def on_show_diff(self, message: ShowDiff) -> None:
+        await self._open_diff(message.left_commit, message.right_commit)
 
     def on_close_diff_table(self, message: CloseDiffTable):
         assert self.diff_table is not None

--- a/scripts/git-review-rebase/src/git_review_rebase/app.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/app.py
@@ -154,25 +154,30 @@ class GitReviewRebase(App):
         self.rebase_table.focus()
         self.refresh_bindings()
 
-    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+    async def _open_diff(
+        self,
+        left_commit: pygit2.Commit | None,
+        right_commit: pygit2.Commit | None,
+    ) -> None:
         assert self.diff_table is not None
+        assert self.rebase_table is not None
+        self.rebase_table.styles.height = "20%"
+        self.diff_table.styles.height = "80%"
+        async with self.diff_table.reload_lock:
+            self.diff_table.load_commit_diff(left_commit, right_commit)
+            await self.diff_table.show_diff()
+        self.diff_table.focus()
+        self.active_table = self.diff_table
+        self.refresh()
+
+    async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         assert self.rebase_table is not None
 
         if event.data_table == self.rebase_table:
-            assert event.row_key.value is not None
-            self.rebase_table.styles.height = "20%"
-            self.diff_table.styles.height = "80%"
-            async with self.diff_table.reload_lock:
-                assert self.rebased_commits_matches is not None
-                assert isinstance(event.row_key.value, pygit2.Oid)
-                self.diff_table.load_commit_diff(
-                    self.rebased_commits_matches.commit_matches[event.row_key.value].left_commit,
-                    self.rebased_commits_matches.commit_matches[event.row_key.value].right_commit,
-                )
-                await self.diff_table.show_diff()
-            self.diff_table.focus()
-            self.active_table = self.diff_table
-            self.refresh()
+            assert self.rebased_commits_matches is not None
+            assert isinstance(event.row_key.value, pygit2.Oid)
+            match = self.rebased_commits_matches.commit_matches[event.row_key.value]
+            await self._open_diff(match.left_commit, match.right_commit)
 
     def on_close_diff_table(self, message: CloseDiffTable):
         assert self.diff_table is not None

--- a/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
@@ -1,6 +1,7 @@
 """Git utility functions for repository operations."""
 
 import multiprocessing
+import re
 from multiprocessing.managers import DictProxy
 
 import pygit2
@@ -94,6 +95,14 @@ def patchids(
                 [(str(oid), cache_flags) for oid in commits_oids],
             )
         return dict(_commit_by_patchid_str)
+
+
+_CHERRY_PICK_RE = re.compile(r"\(cherry picked from commit ([0-9a-f]{40})\)")
+
+
+def cherry_pick_parents(commit: pygit2.Commit) -> list[str]:
+    """Return sha1 strings from '(cherry picked from commit ...)' lines in commit message."""
+    return _CHERRY_PICK_RE.findall(commit.message)
 
 
 def abbrev(oid: pygit2.Oid):

--- a/scripts/git-review-rebase/src/git_review_rebase/ui/cherry_pick_screen.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/ui/cherry_pick_screen.py
@@ -1,0 +1,103 @@
+"""Cherry-pick selection screen for choosing a left commit in the side-by-side diff."""
+
+import subprocess
+
+import pygit2
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Label
+
+from ..constants import SolarizedColors
+from ..git_utils import abbrev, commit_title
+from .utils import cell, cell_from_commit
+
+
+def _name_rev(repo: pygit2.Repository, commit: pygit2.Commit) -> str:
+    result = subprocess.run(
+        ["git", "-C", repo.workdir, "name-rev", "--name-only", str(commit.id)],
+        capture_output=True,
+        text=True,
+    )
+    name = result.stdout.strip()
+    return "" if name == "undefined" else name
+
+
+def _commit_cell(repo: pygit2.Repository, commit: pygit2.Commit) -> Text:
+    c = Text("")
+    c.append(abbrev(commit.id), SolarizedColors.Yellow)
+    name = _name_rev(repo, commit)
+    if name:
+        c.append(f" ({name})", SolarizedColors.Red)
+    c.append(f" {commit_title(commit)}")
+    return cell(c)
+
+
+class CherryPickScreen(ModalScreen):
+    CSS = """
+    CherryPickScreen {
+        align: center middle;
+    }
+
+    #cherry_pick_dialog {
+        background: $panel;
+        border: thick $primary;
+        width: 90;
+        height: auto;
+        max-height: 30;
+        padding: 1 2;
+    }
+
+    #cherry_pick_table {
+        height: auto;
+        max-height: 20;
+    }
+    """
+
+    BINDINGS = [("escape", "cancel", "Cancel")]
+
+    def __init__(
+        self,
+        right_commit: pygit2.Commit,
+        cherry_pick_commits: list[pygit2.Commit],
+        repo: pygit2.Repository,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.right_commit = right_commit
+        self.cherry_pick_commits = cherry_pick_commits
+        self.repo = repo
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="cherry_pick_dialog"):
+            yield Label(Text("Select left commit for: ") + cell_from_commit(self.right_commit))
+            yield Label("")
+            yield DataTable(id="cherry_pick_table")
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = "row"
+        table.show_header = False
+        table.add_column("commit")
+
+        none_text = Text("none", SolarizedColors.Base01)
+        table.add_row(none_text, key="none")
+
+        for commit in self.cherry_pick_commits:
+            table.add_row(_commit_cell(self.repo, commit), key=str(commit.id))
+
+        table.focus()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.row_key.value == "none":
+            self.dismiss(None)
+        else:
+            for commit in self.cherry_pick_commits:
+                if str(commit.id) == event.row_key.value:
+                    self.dismiss(commit)
+                    return
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/scripts/git-review-rebase/src/git_review_rebase/ui/rebase_table.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/ui/rebase_table.py
@@ -5,12 +5,26 @@ import subprocess
 
 import pygit2
 from rich.text import Text
+from textual.message import Message
 from textual.widgets import DataTable
 
 from ..commit_matching import RebasedCommitsMatches
 from ..constants import CommitMatchInfoFlag, FilterType, commit_match_info_repr
+from ..git_utils import cherry_pick_parents
+from .cherry_pick_screen import CherryPickScreen
 from .search_bar import SearchBar
 from .utils import cell_from_commit
+
+
+class ShowDiff(Message):
+    def __init__(
+        self,
+        left_commit: pygit2.Commit | None,
+        right_commit: pygit2.Commit | None,
+    ):
+        super().__init__()
+        self.left_commit = left_commit
+        self.right_commit = right_commit
 
 
 class RebaseTable(DataTable):
@@ -50,6 +64,34 @@ class RebaseTable(DataTable):
         self.row_key = event.row_key
 
     def action_show_diff(self) -> None:
+        assert self.rebased_commit_matches is not None
+        assert isinstance(self.row_key.value, pygit2.Oid)
+        match = self.rebased_commit_matches.commit_matches[self.row_key.value]
+
+        if CommitMatchInfoFlag.Added in match.match_info:
+            assert match.right_commit is not None
+            cherry_sha1s = cherry_pick_parents(match.right_commit)
+            if cherry_sha1s:
+                cherry_commits: list[pygit2.Commit] = []
+                for sha1 in cherry_sha1s:
+                    try:
+                        commit = self.repo.get(pygit2.Oid(hex=sha1))
+                        if isinstance(commit, pygit2.Commit):
+                            cherry_commits.append(commit)
+                    except Exception:
+                        pass
+                if cherry_commits:
+                    right_commit = match.right_commit
+
+                    def handle_selection(result, right: pygit2.Commit = right_commit) -> None:
+                        if result is not False:
+                            self.post_message(ShowDiff(result, right))
+
+                    self.app.push_screen(
+                        CherryPickScreen(right_commit, cherry_commits, self.repo), handle_selection
+                    )
+                    return
+
         self.action_select_cursor()
 
     def on_mount(self) -> None:


### PR DESCRIPTION
This partially implements https://github.com/xcp-ng/hypervisor-dev/issues/11 except it finds matching upstream commits by looking at the `(cherry picked from <sha1>)` line that is added by `git cherry-pick -x` in commit description.

A future PR will add more candidates upstream commits by walking a reviewer-provided ref and trying to find commits with matching titles to fully implement the above issue.

To test, I suggest using the https://github.com/xcp-ng/linux repository with an incantation like this:

```bash
git-review-rebase --no-upstream-patchid v5.10.253^{commit}..v5.10.254^{commit}  vates/kernel/xcpng-4.19.19-8.0.46.1/base..vates/kernel/xcpng-4.19.19-8.0.46.1/base-quentin-copyfail-wip
```

And clicking enter on a newly added commit.  The UI is a bit slugish to present the options currently because I synchronously run `git name-rev` on the candidates commits to give an idea to the reviewer where they come from.  A future improvement could make this run in the background and only present it when the information is available but it is outside of the scope of this PR.