### PR TITLE
docker/riscv/trixie: add domU guest creation support

### DIFF
--- a/docker/riscv/trixie/Makefile
+++ b/docker/riscv/trixie/Makefile
@@ -73,6 +73,9 @@ setup: ## Register QEMU binfmt emulators (run once after each reboot)
 build-image: ## Build the Docker image locally from image/
 	docker buildx build --platform linux/amd64 -f image/Dockerfile -t $(IMAGE) image/
 
+build-image-debug: ## Build the Docker image with debug tools (gdb) included
+	docker buildx build --platform linux/amd64 --build-arg DEBUG_XL=1 -f image/Dockerfile -t $(IMAGE) image/
+
 shell: ## Open an interactive shell in the container
 	$(DOCKER) -p 1234:1234 $(IMAGE) /bin/bash
 

--- a/docker/riscv/trixie/Makefile
+++ b/docker/riscv/trixie/Makefile
@@ -29,12 +29,18 @@ DOCKER := docker run --rm -it \
 
 # Override the pre-compiled kernel bundled in the Docker image
 ifdef KERNEL
+ifeq ($(wildcard $(KERNEL)),)
+$(error KERNEL file not found: $(KERNEL))
+endif
 DOCKER += -v "$(KERNEL)":/build/kernel/Image.gz \
           -e "KERNEL=/build/kernel/Image.gz"
 endif
 
 # Mount vmlinux for GDB kernel symbol loading
 ifdef VMLINUX
+ifeq ($(wildcard $(VMLINUX)),)
+$(error VMLINUX file not found: $(VMLINUX))
+endif
 DOCKER += -v "$(VMLINUX)":/build/vmlinux \
           -e "VMLINUX=/build/vmlinux"
 endif

--- a/docker/riscv/trixie/Makefile
+++ b/docker/riscv/trixie/Makefile
@@ -83,17 +83,9 @@ run: ## Boot Xen + dom0 in QEMU
 	$(DOCKER) -p 1234:1234 $(IMAGE) \
 		/bin/bash -c "make $(INITRD) && make go"
 
-run-rebuild: ## Rebuild Xen hypervisor, then boot
-	$(DOCKER) -p 1234:1234 $(IMAGE) \
-		/bin/bash -c "make build-xen && make $(INITRD) && make go"
-
 debug: ## Boot Xen in QEMU, wait for GDB on port 1234
 	$(DOCKER) -p 1234:1234 $(IMAGE) \
 		/bin/bash -c "make $(INITRD) && make go-debug"
-
-debug-rebuild: ## Rebuild Xen, then boot in GDB-wait mode
-	$(DOCKER) -p 1234:1234 $(IMAGE) \
-		/bin/bash -c "make build-xen && make $(INITRD) && make go-debug"
 
 # VMLINUX is optional: without it, GDB loads Xen symbols only.
 gdb: ## Attach GDB (TUI) to a running Xen instance

--- a/docker/riscv/trixie/image/Dockerfile
+++ b/docker/riscv/trixie/image/Dockerfile
@@ -102,14 +102,12 @@ RUN mkdir -p lib && \
     done
 
 
-WORKDIR ${BUILD_DIR}
-
+WORKDIR ${TMP_DOMU_INITRD_DIR}
+COPY --from=busybox-builder /busybox-install .
 # Build minimal domU initrd from busybox
 RUN mkdir -p ${TMP_DOMU_INITRD_DIR}/bin ${TMP_DOMU_INITRD_DIR}/sbin \
              ${TMP_DOMU_INITRD_DIR}/proc ${TMP_DOMU_INITRD_DIR}/sys \
              ${TMP_DOMU_INITRD_DIR}/dev ${TMP_DOMU_INITRD_DIR}/etc/init.d && \
-    cp -a ${INITRD_DIR}/bin/busybox ${TMP_DOMU_INITRD_DIR}/bin/ && \
-    ${TMP_DOMU_INITRD_DIR}/bin/busybox --install -s ${TMP_DOMU_INITRD_DIR}/bin/ && \
     printf '%s\n' \
         '#!/bin/sh' \
         'mount -t proc proc /proc' \
@@ -122,6 +120,7 @@ RUN mkdir -p ${TMP_DOMU_INITRD_DIR}/bin ${TMP_DOMU_INITRD_DIR}/sbin \
     genext2fs -b 4096 -N 512 -U -d ${TMP_DOMU_INITRD_DIR}/ ${DOMU_INITRD_IMG} && \
     rm -rf ${TMP_DOMU_INITRD_DIR}
 
+WORKDIR ${BUILD_DIR}
 # External binaries
 COPY --from=kernel-riscv64 \
     /Image.gz ${ARTIFACTS_DIR}/Image.gz

--- a/docker/riscv/trixie/image/Dockerfile
+++ b/docker/riscv/trixie/image/Dockerfile
@@ -7,6 +7,21 @@
 FROM baptleduc/xen-riscv64-kernel:6.18 AS kernel-riscv64
 FROM registry.gitlab.com/xen-project/people/olkur/xen/tests-artifacts/qemu-system-riscv64:8.2.0-aia-riscv64 AS qemu-aia-riscv64
 
+FROM debian:trixie-slim AS dtc-riscv64
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential gcc-riscv64-linux-gnu libc6-dev-riscv64-cross \
+        make bison flex pkg-config curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+ARG DTC_VER=1.7.0
+RUN curl -fsSL https://github.com/dgibson/dtc/archive/refs/tags/v${DTC_VER}.tar.gz \
+        | tar xz && \
+    cd dtc-${DTC_VER} && \
+    make NO_PYTHON=1 NO_YAML=1 \
+         CC=riscv64-linux-gnu-gcc \
+         PREFIX=/dtc-install install-bin && \
+    riscv64-linux-gnu-strip /dtc-install/bin/dtc
+
 FROM debian:trixie-slim AS busybox-builder
 
 ARG BUSYBOX_VER=1.36.1
@@ -53,6 +68,9 @@ ENV XEN_DIST_DIR=/build/xen/dist
 ARG DOMU_INITRD_DIR=/build/domu-initrd
 ENV DOMU_INITRD_IMG=${DOMU_INITRD_DIR}/domu-initrd.img
 ARG TMP_DOMU_INITRD_DIR=/tmp/domu-initrd
+
+# Debug tools (opt-in via --build-arg DEBUG_XL=1)
+ARG DEBUG_XL=0
 
 # Cross-compilation settings
 ENV DEBIAN_FRONTEND=noninteractive
@@ -101,6 +119,10 @@ RUN mkdir -p lib && \
         cp "$lib" ./lib/; \
     done
 
+RUN --mount=type=bind,from=dtc-riscv64,source=/dtc-install,target=/dtc-stage \
+    if [ "${DEBUG_XL}" = "1" ]; then \
+        cp /dtc-stage/bin/dtc ./bin/dtc; \
+    fi
 
 WORKDIR ${TMP_DOMU_INITRD_DIR}
 COPY --from=busybox-builder /busybox-install .

--- a/docker/riscv/trixie/image/Makefile
+++ b/docker/riscv/trixie/image/Makefile
@@ -147,9 +147,10 @@ initrd-tools: dist-tools create-tools-dirs ## Create initrd with Xen tools inclu
 	'mount -t devpts devpts /dev/pts' \
 	'mount -t sysfs sysfs /sys' \
 	'export LIBXL_DEBUG_DUMP_DTB="/var/log/xen/debug_dump_dt.dtb"' \
-	'./dist/install/usr/local/sbin/xenstored' \
-	'./dist/install/usr/local/sbin/xenconsoled' \
-	'sleep 1' \
+	'export PATH=$$PATH:/dist/install/usr/local/sbin' \
+	'xenstored' \
+	'xenconsoled' \
+	'sleep 0.5' \
 	'./lib/xen/bin/xen-init-dom0' \
 	'exec /bin/sh' \
 	> $(RCS_FILE) && \

--- a/docker/riscv/trixie/image/Makefile
+++ b/docker/riscv/trixie/image/Makefile
@@ -106,9 +106,6 @@ dist-tools: $(XEN_CONFIGURE_OUT) ## Build and install Xen tools to /dist
 dist-xen: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build and install Xen hypervisor to /dist
 	$(MAKE) -C $(XEN_ROOT)/xen install DESTDIR=$(XEN_ROOT) -j$(nproc)
 
-install: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT)
-	$(MAKE) -C $(XEN_ROOT) install DESTDIR=$(INITRD_DIR) -j$(nproc)
-
 dist: dist-tools dist-xen ## Build and install both tools and Xen to /dist
 
 # Uses the Xen top-level build-tools (no -j bypass): same rationale as dist-tools.
@@ -120,6 +117,9 @@ build-xen: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build Xen hypervisor
 	$(MAKE) -C $(XEN_ROOT)/xen -j$(nproc)
 
 build: build-tools build-xen ## Build both Xen tools and hypervisor
+
+install: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT)
+	$(MAKE) -C $(XEN_ROOT) install SUBSYSTEM="xen tools" DESTDIR=$(INITRD_DIR) -j$(nproc)
 
 # --- Initrd targets ---
 

--- a/docker/riscv/trixie/image/Makefile
+++ b/docker/riscv/trixie/image/Makefile
@@ -152,9 +152,6 @@ initrd-tools: install create-tools-dirs ## Create initrd with Xen tools included
 	'xenconsoled -vvvv' \
 	'sleep 0.5' \
 	'/usr/lib/xen/bin/xen-init-dom0' \
-	'xl cpupool-create name=\"test\"' \
-	'xl cpupool-cpu-remove Pool-0 1' \
-	'xl cpupool-cpu-add test 1' \
 	'exec /bin/sh' \
 	> $(RCS_FILE) && \
 	chmod +x $(RCS_FILE)

--- a/docker/riscv/trixie/image/Makefile
+++ b/docker/riscv/trixie/image/Makefile
@@ -26,7 +26,7 @@ XEN_MAKE := $(MAKE) -C $(XEN_ROOT) -j$(nproc)
 
 QEMU_BASE_FLAGS = \
 	-M virt,aclint=off,aia=aplic-imsic,aia-guests=7 \
-	-cpu rv64,smstateen=on \
+	-cpu rv64,smstateen=on,sstc=off\
 	-bios $(OPENSBI) \
 	-smp 2 \
 	-nographic \
@@ -58,7 +58,7 @@ GDB_ARGS += \
 	-ex "b start_xen" \
 	-ex "c"
 
-.PHONY: all clean help initrd-tools dist-tools dist-xen dist build-tools build-xen build go go-debug gdb initrd create-common-dirs create-tools-dirs
+.PHONY: all clean help initrd-tools dist-tools dist-xen dist build-tools build-xen build go go-debug gdb initrd create-common-dirs create-tools-dirs install
 
 help: ## Display this help message
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
@@ -67,7 +67,7 @@ help: ## Display this help message
 # --- Internal targets ---
 
 $(XEN_CONFIGURE_OUT): $(XEN_ROOT)/configure
-	cd $(XEN_ROOT) && ./configure --host=riscv64-linux-gnu
+	cd $(XEN_ROOT) && ./configure --prefix=/usr --host=riscv64-linux-gnu
 
 $(XEN_CONFIG):
 	cp $(CONFIGS_DIR)/.config $(XEN_CONFIG)
@@ -104,7 +104,10 @@ dist-tools: $(XEN_CONFIGURE_OUT) ## Build and install Xen tools to /dist
 
 # Use sub-make to preserve parallel build (-j$(nproc) not propagated by top-level Xen build)
 dist-xen: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build and install Xen hypervisor to /dist
-	$(MAKE) -C $(XEN_ROOT)/xen install DESTDIR=$(XEN_ROOT)/dist/install -j$(nproc)
+	$(MAKE) -C $(XEN_ROOT)/xen install DESTDIR=$(XEN_ROOT) -j$(nproc)
+
+install: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT)
+	$(MAKE) -C $(XEN_ROOT) install DESTDIR=$(INITRD_DIR) -j$(nproc)
 
 dist: dist-tools dist-xen ## Build and install both tools and Xen to /dist
 
@@ -134,10 +137,8 @@ initrd: $(INITRD_STAMP) create-common-dirs ## Create basic initrd image
 	cp $(RCS_FILE) $(INITRD_DIR)/etc/init.d/
 	genext2fs -b 6500 -N 1024 -U -d $(INITRD_DIR)/ $(INITRD)
 
-initrd-tools: dist-tools create-tools-dirs ## Create initrd with Xen tools included
+initrd-tools: install create-tools-dirs ## Create initrd with Xen tools included
 	echo "Building initrd with tools image"
-	cp -r $(XEN_ROOT)/dist/* $(INITRD_DIR)/dist/
-	mv $(INITRD_DIR)/dist/install/usr/local/lib/* $(INITRD_DIR)/lib/
 	printf '%s\n' \
 	'#!/bin/sh' \
 	'echo "Hello RISC-V World!"' \
@@ -147,11 +148,13 @@ initrd-tools: dist-tools create-tools-dirs ## Create initrd with Xen tools inclu
 	'mount -t devpts devpts /dev/pts' \
 	'mount -t sysfs sysfs /sys' \
 	'export LIBXL_DEBUG_DUMP_DTB="/var/log/xen/debug_dump_dt.dtb"' \
-	'export PATH=$$PATH:/dist/install/usr/local/sbin' \
 	'xenstored' \
-	'xenconsoled' \
+	'xenconsoled -vvvv' \
 	'sleep 0.5' \
-	'./lib/xen/bin/xen-init-dom0' \
+	'/usr/lib/xen/bin/xen-init-dom0' \
+	'xl cpupool-create name=\"test\"' \
+	'xl cpupool-cpu-remove Pool-0 1' \
+	'xl cpupool-cpu-add test 1' \
 	'exec /bin/sh' \
 	> $(RCS_FILE) && \
 	chmod +x $(RCS_FILE)

--- a/docker/riscv/trixie/image/Makefile
+++ b/docker/riscv/trixie/image/Makefile
@@ -58,7 +58,7 @@ GDB_ARGS += \
 	-ex "b start_xen" \
 	-ex "c"
 
-.PHONY: all clean help initrd-tools dist-tools dist-xen dist build-tools build-xen build go go-debug gdb initrd create-common-dirs create-tools-dirs install
+.PHONY: all clean help initrd-tools install-tools install-xen install build-tools build-xen build go go-debug gdb initrd create-common-dirs create-tools-dirs
 
 help: ## Display this help message
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
@@ -97,45 +97,43 @@ create-tools-dirs: create-common-dirs
 
 # --- Build targets ---
 
-# Uses the Xen top-level dist-tools (no -j bypass): replicating it requires
-# running install-tools-public-headers first, which adds complexity.
-dist-tools: $(XEN_CONFIGURE_OUT) ## Build and install Xen tools to /dist
-	$(XEN_MAKE) dist-tools
-
-# Use sub-make to preserve parallel build (-j$(nproc) not propagated by top-level Xen build)
-dist-xen: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build and install Xen hypervisor to /dist
-	$(MAKE) -C $(XEN_ROOT)/xen install DESTDIR=$(XEN_ROOT) -j$(nproc)
-
-dist: dist-tools dist-xen ## Build and install both tools and Xen to /dist
-
-# Uses the Xen top-level build-tools (no -j bypass): same rationale as dist-tools.
 build-tools: $(XEN_CONFIGURE_OUT) ## Build Xen tools
 	$(XEN_MAKE) build-tools
 
-# Use sub-make to preserve parallel build (-j$(nproc) not propagated by top-level Xen build)
 build-xen: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build Xen hypervisor
-	$(MAKE) -C $(XEN_ROOT)/xen -j$(nproc)
+	$(XEN_MAKE) build-xen
 
-build: build-tools build-xen ## Build both Xen tools and hypervisor
+build: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build Xen hypervisor and tools
+	$(XEN_MAKE) build SUBSYSTEMS="xen tools"
 
-install: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT)
-	$(MAKE) -C $(XEN_ROOT) install SUBSYSTEM="xen tools" DESTDIR=$(INITRD_DIR) -j$(nproc)
+# --- Install targets ---
+
+install-tools: $(XEN_CONFIGURE_OUT) ## Build and install Xen tools to INITRD_DIR
+	$(XEN_MAKE) install-tools DESTDIR=$(INITRD_DIR)
+
+install-xen: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build and install Xen hypervisor to INITRD_DIR
+	$(XEN_MAKE) install-xen DESTDIR=$(INITRD_DIR)
+
+install: $(XEN_CONFIG) $(XEN_CONFIGURE_OUT) ## Build and install Xen hypervisor and tools to INITRD_DIR
+	$(XEN_MAKE) install DESTDIR=$(INITRD_DIR) SUBSYSTEMS="xen tools"
 
 # --- Initrd targets ---
 
-initrd: $(INITRD_STAMP) create-common-dirs ## Create basic initrd image
+initrd: $(INITRD_STAMP) install-xen create-common-dirs ## Create basic initrd image
 	echo "Building initrd image"
 	printf '%s\n' \
 	'#!/bin/sh' \
 	'echo "Hello RISC-V World!"' \
 	'mount -t proc proc /proc' \
 	'mount -t xenfs xenfs /proc/xen' \
+	'mkdir -p /dev/pts/' \
+	'mount -t devpts devpts /dev/pts' \
 	'mount -t sysfs sysfs /sys' \
 	'exec /bin/sh' \
 	> $(RCS_FILE) && \
 	chmod +x $(RCS_FILE)
 	cp $(RCS_FILE) $(INITRD_DIR)/etc/init.d/
-	genext2fs -b 6500 -N 1024 -U -d $(INITRD_DIR)/ $(INITRD)
+	genext2fs -b 10000 -N 1024 -U -d $(INITRD_DIR)/ $(INITRD)
 
 initrd-tools: install create-tools-dirs ## Create initrd with Xen tools included
 	echo "Building initrd with tools image"

--- a/docker/riscv/trixie/image/domu.cfg
+++ b/docker/riscv/trixie/image/domu.cfg
@@ -4,7 +4,5 @@ kernel = "/domu/Image.gz"
 ramdisk = "/domu/initrd.img"
 memory = 256
 cpus = "1"
-pool = "test"
-cpus_soft = "1"
 vcpus = 1
 extra = "console=hvc0 keep_bootcon rw root=/dev/ram"

--- a/docker/riscv/trixie/image/domu.cfg
+++ b/docker/riscv/trixie/image/domu.cfg
@@ -3,5 +3,8 @@ type = "pvh"
 kernel = "/domu/Image.gz"
 ramdisk = "/domu/initrd.img"
 memory = 256
+cpus = "1"
+pool = "test"
+cpus_soft = "1"
 vcpus = 1
-extra = "console=hvc0 rw root=/dev/ram"
+extra = "console=hvc0 keep_bootcon rw root=/dev/ram"

--- a/docker/riscv/trixie/image/generate_dtb.sh
+++ b/docker/riscv/trixie/image/generate_dtb.sh
@@ -54,7 +54,7 @@ generate_base_dts() {
     local ic_flags=""
     case $platform_interrupt_controller in
         aplic-imsic)
-            ic_flags=",aclint=off,aia=aplic-imsic,aia-guests=7 -cpu rv64,smstateen=on"
+            ic_flags=",aclint=off,aia=aplic-imsic,aia-guests=7 -cpu rv64,smstateen=on,sstc=off"
             ;;
     esac
 


### PR DESCRIPTION
 Adds support for creating and running domU guests in the RISC-V QEMU environment. 

**Features**:
- Add install Makefile target that installs Xen tools + hypervisor directly to `INITRD_DIR` with correct prefix (`/usr`), replacing the previous dist-based approach with path gymnastics
- Simplify initrd-tools rcS script by using direct env variables name.
- Add build-image-debug target to build Docker image with `dtc` cross-compiled for RISC-V (opt-in via DEBUG_XL=1)
- Add build-time validation: error early if `KERNEL` or `VMLINUX` paths don't exist
- Disable unsupported sstc CPU extension
- Fix domU config: add `cpus = "1"`, add keep_bootcon to kernel cmdline for better console output

**Test**
- Launch `xl create domu/domu.cfg` from dom0 on this xen worktree: https://gitlab.com/xen-project/people/olkur/xen/-/tree/dev-riscv-support-guest-domains?ref_type=heads