### PR TITLE
git-review-rebase: correctly handle empty lines in blame output.

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/ui/diff_table.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/ui/diff_table.py
@@ -192,7 +192,7 @@ class DiffPrettyRowMaker:
             return (Text(""), Text(""), Text(""))
 
         left_diff_line, middle_char, right_diff_line = (
-            line[: self.middle_point].rstrip(),
+            line[: self.middle_point].rstrip() or " ",
             line[self.middle_point],
             line[self.middle_point + self.right_first_char_index :],
         )


### PR DESCRIPTION
`git-review-rebase` will remove space characters with rstrip() on the left side of the diff, as those are otherwise interpreted as part of the diff when they can be just fillers to align the rest.  As a result though, the diff parser does not see an expected space as the first character for lines that have not changed and are empty, messing up with the logic to record the position within the file.

This would manifest as the wrong blame commit being selected after the first empty line on the left side.

Reported-by: Ngoc-Tu Dinh <ngoc-tu.dinh@vates.tech>