### PR TITLE
docker/riscv/trixie: Add build-kernel target

### DIFF
--- a/docker/riscv/trixie/Makefile
+++ b/docker/riscv/trixie/Makefile
@@ -11,8 +11,8 @@
 
 -include config.mk
 
-ifndef XEN_HOST
-$(error XEN_HOST is not set. Copy config.mk.example to config.mk and fill in your paths.)
+ifndef XEN_SRC
+$(error XEN_SRC is not set. Copy config.mk.example to config.mk and fill in your paths.)
 endif
 
 IMAGE ?= baptleduc/xen-riscv64-trixie:latest
@@ -25,10 +25,12 @@ XEN_DIR   := $(BUILD_DIR)/xen
 
 DOCKER := docker run --rm -it \
 	--platform linux/amd64 \
-	-v "$(XEN_HOST)":$(XEN_DIR)
+	-v "$(XEN_SRC)":$(XEN_DIR)
 
-# Override the pre-compiled kernel bundled in the Docker image
 ifdef KERNEL
+ifeq ($(wildcard $(KERNEL)),)
+$(error KERNEL file not found: $(KERNEL))
+endif
 DOCKER += -v "$(KERNEL)":/build/kernel/Image.gz \
           -e "KERNEL=/build/kernel/Image.gz"
 endif
@@ -45,7 +47,7 @@ ifneq ($(filter $(INITRD),$(VALID_INITRD)),$(INITRD))
 $(error INITRD must be one of: $(VALID_INITRD) (got '$(INITRD)'))
 endif
 
-.PHONY: help setup build-image shell run run-rebuild debug debug-rebuild gdb gdb-rebuild clean
+.PHONY: help setup build-kernel build-image shell run run-rebuild debug debug-rebuild gdb gdb-rebuild clean
 
 help: ## Show this help message
 	@echo "Targets:"
@@ -56,13 +58,20 @@ help: ## Show this help message
 	@echo "  INITRD=initrd        Minimal initrd (default)"
 	@echo "  INITRD=initrd-tools  Initrd with Xen tools included"
 	@echo "  IMAGE=<tag>          Docker image (default: $(IMAGE))"
-	@echo "  KERNEL=<path>        Local kernel binary, overrides the image default"
+	@echo "  KERNEL=<path>        Pre-built kernel image, overrides the bundled one"
 	@echo "  VMLINUX=<path>       Path to vmlinux, enables kernel symbols in GDB"
 	@echo ""
 	@echo "Local config: config.mk (copy from config.mk.example)"
 
 setup: ## Register QEMU binfmt emulators (run once after each reboot)
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+build-kernel: ## Build local Linux kernel (requires KERNEL_SRC=<path>)
+ifndef KERNEL_SRC
+	$(error KERNEL_SRC is not set. Set it in config.mk.)
+endif
+	docker run --rm -v "$(KERNEL_SRC)":/build/linux tuxmake/riscv_gcc-14 \
+		/bin/bash -c "make -C /build/linux ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- -j$$(nproc) xen_defconfig Image.gz"
 
 build-image: ## Build the Docker image locally from image/
 	docker buildx build --platform linux/amd64 -f image/Dockerfile -t $(IMAGE) image/

--- a/docker/riscv/trixie/README.md
+++ b/docker/riscv/trixie/README.md
@@ -62,7 +62,8 @@ It is built from [`baptleduc/linux-xen-riscv`](https://github.com/baptleduc/linu
 a patched Linux tree adding RISC-V Xen guest support.
 Versioned tags follow the `vX.X.X-xen-riscv` scheme.
 
-To use a locally built kernel instead, set `KERNEL` in `config.mk`.
+To override the bundled kernel, set `KERNEL` in `config.mk` to any pre-built `Image.gz`.
+To build one from source, use `make build-kernel KERNEL_SRC=<path>` (see [Boot Xen with a locally built kernel](#boot-xen-with-a-locally-built-kernel)).
 
 ## Usage
 
@@ -75,6 +76,7 @@ make <target> [INITRD=initrd|initrd-tools]
 | Target          | Description                                          |
 |-----------------|------------------------------------------------------|
 | `setup`         | Register QEMU binfmt emulators (once after reboot)   |
+| `build-kernel`  | Cross-compile `Image.gz` from `KERNEL_SRC` source tree |
 | `build-image`   | Build the Docker image locally from `image/`         |
 | `shell`         | Open an interactive shell in the container           |
 | `run`           | Boot Xen + dom0 in QEMU                              |
@@ -104,20 +106,23 @@ make run INITRD=initrd-tools
 make run
 ```
 
-### Boot Xen with a locally built kernel
+### Boot Xen with a custom kernel
 
-Build the kernel from [`baptleduc/linux-xen-riscv`](https://github.com/baptleduc/linux-xen-riscv/tree/6.18-xen-guest-support):
+Set `KERNEL` in `config.mk` to any pre-built `Image.gz`:
 
-```sh
-make ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- -j$(nproc) xen_defconfig Image.gz
+```makefile
+# config.mk
+KERNEL := $(HOME)/path/to/Image.gz
 ```
 
-Then set `KERNEL` in `config.mk` and run:
+```sh
+make run
+```
+
+To build a kernel from source, use the `build-kernel` target with your Linux source tree so it can cross-compiles `Image.gz` using `tuxmake/riscv_gcc-14` (no local toolchain needed):
 
 ```sh
-# In config.mk:
-# KERNEL := $(HOME)/path/to/linux/arch/riscv/boot/Image.gz
-make run
+make build-kernel KERNEL_SRC=$(HOME)/path/to/linux
 ```
 
 ### Rebuild Xen and boot

--- a/docker/riscv/trixie/config.mk.example
+++ b/docker/riscv/trixie/config.mk.example
@@ -7,7 +7,7 @@
 # ==============================================================================
 
 # Path to the Xen source tree on your machine (required)
-XEN_HOST := $(HOME)/Documents/Vates/xen
+XEN_SRC := $(HOME)/Documents/Vates/xen
 
 # Docker image to use (optional, defaults to baptleduc/xen-riscv64-trixie:latest).
 # Override to use a locally built image (e.g. after make build-image).

--- a/docker/riscv/trixie/image/Dockerfile
+++ b/docker/riscv/trixie/image/Dockerfile
@@ -4,7 +4,8 @@
 # syntax=docker/dockerfile:1
 
 # Images imports
-FROM baptleduc/xen-riscv64-kernel:6.18 AS kernel-riscv64
+ARG KERNEL_IMAGE_TAG=latest
+FROM baptleduc/xen-riscv64-kernel:${KERNEL_IMAGE_TAG} AS kernel-riscv64
 FROM registry.gitlab.com/xen-project/people/olkur/xen/tests-artifacts/qemu-system-riscv64:8.2.0-aia-riscv64 AS qemu-aia-riscv64
 
 FROM debian:trixie-slim AS busybox-builder

--- a/docker/riscv/trixie/image/Makefile
+++ b/docker/riscv/trixie/image/Makefile
@@ -160,11 +160,13 @@ initrd-tools: dist-tools create-tools-dirs ## Create initrd with Xen tools inclu
 # --- Run targets ---
 
 go: $(INITRD) $(KERNEL) $(QEMU) $(OPENSBI) $(XEN_BIN) $(DTB_SCRIPT) ## Launch Xen with dom0 in QEMU
+	@echo "Using Linux kernel: $(KERNEL)"
 	cd $(DTB_DIR) && \
 	bash $(DTB_SCRIPT) dom0-domU-test $(DTB_DIR) $(OPENSBI) $(QEMU) $(XEN_BIN) $(KERNEL) $(INITRD)
 	$(QEMU) $(QEMU_BASE_FLAGS)
 
 go-debug: $(INITRD) $(KERNEL) $(QEMU) $(OPENSBI) $(XEN_BIN) $(DTB_SCRIPT) ## Launch Xen in QEMU with GDB server waiting on port 1234
+	@echo "Using Linux kernel: $(KERNEL)"
 	cd $(DTB_DIR) && \
 	bash $(DTB_SCRIPT) dom0-domU-test $(DTB_DIR) $(OPENSBI) $(QEMU) $(XEN_BIN) $(KERNEL) $(INITRD)
 	$(QEMU) $(QEMU_BASE_FLAGS) $(QEMU_DEBUG_FLAGS)


### PR DESCRIPTION
Adds a `build-kernel` target that cross-compiles `Image.gz` from a Linux source tree using `tuxmake/riscv_gcc-14` in Docker. No local RISC-V toolchain required.

```sh
make build-kernel KERNEL_SRC=$(HOME)/path/to/linux
```
The resulting binary can then be used via the existing `KERNEL` variable to override the bundled kernel at boot time.