### PR TITLE
docker/riscv: add linux-xen-riscv submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -265,3 +265,6 @@
 [submodule "driver-disks"]
 	path = driver-disks
 	url = git@github.com:xcp-ng/driver-disks.git
+[submodule "docker/riscv/linux-xen-riscv"]
+	path = docker/riscv/linux-xen-riscv
+	url = git@github.com:baptleduc/linux-xen-riscv.git

--- a/docker/riscv/README.md
+++ b/docker/riscv/README.md
@@ -1,0 +1,5 @@
+# linux-xen-riscv
+
+Patched Linux kernel tree tracked as a submodule. Source for adding RISC-V Xen domU (guest domain) support to the kernel.
+
+Used as the kernel source for the [`trixie`](trixie/) build environment.

--- a/docker/riscv/trixie/README.md
+++ b/docker/riscv/trixie/README.md
@@ -58,7 +58,7 @@ Edit `config.mk` to configure your local environment.
 ### Pre-built kernel
 
 The default `Image.gz` is pulled from [`baptleduc/xen-riscv64-kernel`](https://hub.docker.com/r/baptleduc/xen-riscv64-kernel).
-It is built from [`baptleduc/linux-xen-riscv`](https://github.com/baptleduc/linux-xen-riscv/tree/6.18-xen-guest-support),
+It is built from the [`linux-xen-riscv`](../linux-xen-riscv) submodule,
 a patched Linux tree adding RISC-V Xen guest support.
 Versioned tags follow the `vX.X.X-xen-riscv` scheme.
 


### PR DESCRIPTION
Track linux-xen-riscv as a submodule, a patched Linux kernel adding RISC-V Xen domU support. 

Add riscv/README.md and update trixie/README to reference the submodule instead of the direct GitHub URL.