### PR TITLE
git-review-rebase: fix incorrect incorrect position in file parsing.

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/ui/diff_table.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/ui/diff_table.py
@@ -197,8 +197,14 @@ class DiffPrettyRowMaker:
             line[self.middle_point + self.right_first_char_index :],
         )
 
-        self.right_diff.parse_line(right_diff_line)
-        self.left_diff.parse_line(left_diff_line)
+        match middle_char:
+            case ">":
+                self.right_diff.parse_line(right_diff_line)
+            case "<":
+                self.left_diff.parse_line(left_diff_line)
+            case _:
+                self.right_diff.parse_line(right_diff_line)
+                self.left_diff.parse_line(left_diff_line)
 
         left, middle, right = await self.stylicize(left_diff_line, middle_char, right_diff_line)
         return cell(left), middle, cell(right)


### PR DESCRIPTION
The recently added ed2a29807781 ("git-review-rebase: correctly handle empty lines in blame output.") fixed a case where an empty line in the left side diff was not counted, but by doing so, it uncovered another bug where lines that were on only one side (either on the left commit or on the right commit) were now counted as an empty line (and as such, with their position now increased thanks to ed2a29807781).

The fix here is not try to parse on the other side where it only exists in one.

This fixes an issue Tu ran into that looked like:
```
│ src/git_review_rebase/ui/diff_table.py:162
│
│
│╭────────────────────────────────────────── locals ───────────────────────────────────────────╮
││  blame_info = <git_review_rebase.blame.BlameInfo object at 0x73fc581d4a70>                  │
││      commit = <pygit2.Object{commit:25d3a30f9bc7c8ee5ae1a82976f6ffb7a0c77859}>              │
││    cur_line = <text ' }' [] ''>                                                             │
││ diff_parser = <git_review_rebase.diff_parser.DiffParser object at 0x73fb190b8b60>           │
││    position = new=arch/x86/kernel/asm-offsets.c+166 old=arch/x86/kernel/asm-offsets.c+148   │
││        self = <git_review_rebase.ui.diff_table.DiffPrettyRowMaker object at 0x73fb190b8c20> │
│╰─────────────────────────────────────────────────────────────────────────────────────────────╯
│
│   159 │   │   │
│   160 │   │   │   assert self.blame_cache is not None
│   161 │   │   │   blame_info = self.blame_cache.get_blame_info(commit.parents[0], position.old
│ ❱ 162 │   │   │   commit = await blame_info.commit_at(position.old_line_number - 1)
│   163 │   │   else:
│   164 │   │   │   # Here, the to be blamed commit is the one we're looking at,
│   165 │   │   │   # because it is the one adding that line, fall-through.
│
│
│╭────────────────────────────────── locals ──────────────────────────────────╮
││ line_number = 147                                                          │
││        self = <git_review_rebase.blame.BlameInfo object at 0x73fc581d4a70> │
│╰────────────────────────────────────────────────────────────────────────────╯
│
│
│ src/git_review_rebase/blame.py:41 in commit_at
│
│   38 │
│   39 │   async def commit_at(self, line_number: int) -> pygit2.Commit:
│   40 │   │   await self._loader
│ ❱ 41 │   │   return self._blame_info[line_number]
│   42
│   43
```
Reported-by: Ngoc-Tu Dinh <ngoc-tu.dinh@vates.tech>