### PR TITLE
git-review-rebase: use fork method when starting multiprocessing manager

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
@@ -86,9 +86,12 @@ def patchids(
     """Return a dict[Commit] -> Patchid."""
     global _repo, _commit_by_patchid_str
     _repo = repo
-    with multiprocessing.Manager() as manager:
+    # Use 'fork' explicitly: forkserver (Python 3.14+ default) fails with -1 fds
+    # when Manager() is called from within asyncio.to_thread().
+    ctx = multiprocessing.get_context("fork")
+    with ctx.Manager() as manager:
         _commit_by_patchid_str = manager.dict()
-        with multiprocessing.Pool(multiprocessing.cpu_count()) as p:
+        with ctx.Pool(multiprocessing.cpu_count()) as p:
             p.starmap(
                 patchid_map_fn,
                 # Oids objects cannot be pickled so use string representation


### PR DESCRIPTION
Yann ran into an issue where the python 3.14 multiprocessing Manager seems to refuse to start with a rather cryptic:

 ValueError: bad value(s) in fds_to_keep

Claude thinks this is because on python-3.14 the default method for manager is "forkserver", which doesn't work in the context of an asyncio.thread.  The fix is to explicitly request the use of the "fork" method.

Reported-by: Yann Sionneau <yann.sionneau@vates.tech>