### PR TITLE
ci(docker): add build workflow for xen-riscv64-trixie image

### DIFF
--- a/.github/workflows/docker-xen-riscv64-trixie.yml
+++ b/.github/workflows/docker-xen-riscv64-trixie.yml
@@ -1,0 +1,48 @@
+name: Build xen-riscv64-trixie
+
+on:
+  push:
+    paths:
+      - 'docker/riscv/trixie/**'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'docker/riscv/trixie/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build (PR - no push)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/riscv/trixie/image
+          file: docker/riscv/trixie/image/Dockerfile
+          platforms: linux/amd64
+          push: false
+
+      - name: Build and push (main)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/riscv/trixie/image
+          file: docker/riscv/trixie/image/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/xen-riscv64-trixie:latest

--- a/.github/workflows/docker-xen-riscv64-trixie.yml
+++ b/.github/workflows/docker-xen-riscv64-trixie.yml
@@ -17,14 +17,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -32,7 +34,7 @@ jobs:
 
       - name: Build (PR - no push)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: docker/riscv/trixie/image
           file: docker/riscv/trixie/image/Dockerfile
@@ -41,7 +43,7 @@ jobs:
 
       - name: Build and push (tag)
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: docker/riscv/trixie/image
           file: docker/riscv/trixie/image/Dockerfile

--- a/.github/workflows/docker-xen-riscv64-trixie.yml
+++ b/.github/workflows/docker-xen-riscv64-trixie.yml
@@ -3,7 +3,7 @@ name: Build xen-riscv64-trixie
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-xen-riscv64'
+      - 'v[0-9]+.[0-9]+.[0-9]+-xen-riscv64-trixie'
   pull_request:
     paths:
       - 'docker/riscv/trixie/**'

--- a/.github/workflows/docker-xen-riscv64-trixie.yml
+++ b/.github/workflows/docker-xen-riscv64-trixie.yml
@@ -2,10 +2,8 @@ name: Build xen-riscv64-trixie
 
 on:
   push:
-    paths:
-      - 'docker/riscv/trixie/**'
-    branches:
-      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-xen-riscv64'
   pull_request:
     paths:
       - 'docker/riscv/trixie/**'
@@ -13,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
@@ -21,12 +22,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (PR - no push)
         if: github.event_name == 'pull_request'
@@ -37,12 +39,12 @@ jobs:
           platforms: linux/amd64
           push: false
 
-      - name: Build and push (main)
-        if: github.event_name != 'pull_request'
+      - name: Build and push (tag)
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: docker/riscv/trixie/image
           file: docker/riscv/trixie/image/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/xen-riscv64-trixie:latest
+          tags: ghcr.io/${{ github.repository_owner }}/xen-riscv64-trixie:${{ github.ref_name }}


### PR DESCRIPTION
Adds a GitHub Actions workflow to build the `docker/riscv/trixie` image. @baptleduc suggested opening this as a dedicated PR upstream (split out from baptleduc/hypervisor-dev#1, which I closed).

- On pull requests touching `docker/riscv/trixie/**`: builds amd64, no push (validates the Dockerfile still builds).
- On pushes to `main` touching the same path: builds and pushes `:latest`.

amd64 only for now. arm64 isn't viable until the AIA + fakedevice-patched QEMU is built for arm64 (it only exists as the amd64 GitLab artifact today), so I left it out rather than ship a broken arm64 image.

**Prerequisite:** the workflow expects `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets for the push step. If you'd prefer a different registry/namespace, or want the push gated to tags / `workflow_dispatch` only, happy to adjust.