### PR TITLE
git-review-rebase: support windows files and empty commit description.

### DIFF
--- a/scripts/git-review-rebase/src/git_review_rebase/commit_matching.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/commit_matching.py
@@ -21,9 +21,14 @@ class RebasedCommitMatch:
         self.match_info = match_info
 
     def __repr__(self) -> str:
+        lc_rep = rc_rep = "None"
+        if self.left_commit is not None:
+            lc_rep = abbrev(self.left_commit.id)
+        if self.right_commit is not None:
+            rc_rep = abbrev(self.right_commit.id)
         return (
-            f"RebasedCommitMatch(left_commit={abbrev(self.left_commit.id)}, "
-            f"right_commit={abbrev(self.right_commit.id)}, "
+            f"RebasedCommitMatch(left_commit={lc_rep}, "
+            f"right_commit={rc_rep}, "
             f"match_info={str(self.match_info)}"
         )
 

--- a/scripts/git-review-rebase/src/git_review_rebase/commit_matching.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/commit_matching.py
@@ -6,7 +6,7 @@ import pygit2
 
 from .branch_range import BranchRange
 from .constants import CommitMatchInfoFlag
-from .git_utils import commit_title
+from .git_utils import abbrev, commit_title
 
 
 class RebasedCommitMatch:
@@ -19,6 +19,13 @@ class RebasedCommitMatch:
         self.left_commit = left_commit
         self.right_commit = right_commit
         self.match_info = match_info
+
+    def __repr__(self) -> str:
+        return (
+            f"RebasedCommitMatch(left_commit={abbrev(self.left_commit.id)}, "
+            f"right_commit={abbrev(self.right_commit.id)}, "
+            f"match_info={str(self.match_info)}"
+        )
 
 
 class RebasedCommitsMatches:

--- a/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
@@ -2,6 +2,7 @@
 
 import multiprocessing
 import re
+from itertools import chain
 from multiprocessing.managers import DictProxy
 
 import pygit2
@@ -100,12 +101,17 @@ def patchids(
         return dict(_commit_by_patchid_str)
 
 
-_CHERRY_PICK_RE = re.compile(r"\(cherry picked from commit ([0-9a-f]{40})\)")
+_CHERRY_PICK_PATTERNS = [
+    re.compile(r"\(cherry picked from commit ([0-9a-f]{40})\)"),
+    re.compile(r"[Cc]ommit ([0-9a-f]{40}) [Uu]pstream"),
+]
 
 
 def cherry_pick_parents(commit: pygit2.Commit) -> list[str]:
     """Return sha1 strings from '(cherry picked from commit ...)' lines in commit message."""
-    return _CHERRY_PICK_RE.findall(commit.message)
+    return list(
+        chain.from_iterable(pattern.findall(commit.message) for pattern in _CHERRY_PICK_PATTERNS)
+    )
 
 
 def abbrev(oid: pygit2.Oid):

--- a/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/git_utils.py
@@ -37,7 +37,7 @@ def range_log(
 
 def commit_title(commit: pygit2.Commit) -> str:
     """Given a Commit object, return the commit title."""
-    return commit.message.splitlines()[0]
+    return (commit.message.splitlines() or [""])[0]
 
 
 def cached_patchid_ref(revision: str) -> str:

--- a/scripts/git-review-rebase/src/git_review_rebase/ui/diff_table.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/ui/diff_table.py
@@ -344,17 +344,21 @@ class DiffTable(DataTable):
             NamedTemporaryFile(mode="w+t") as left_diff_path,
             NamedTemporaryFile(mode="w+t") as right_diff_path,
         ):
-            if self.left_commit:
-                subprocess.run(
-                    build_show_cmd(left_commit),
-                    stdout=left_diff_path,
+
+            def run_show(commit, tmp_file):
+                result = subprocess.run(
+                    build_show_cmd(commit),
+                    capture_output=True,
+                    text=True,
                 )
+                tmp_file.write(result.stdout)
+                tmp_file.flush()
+
+            if self.left_commit:
+                run_show(left_commit, left_diff_path)
 
             if self.right_commit:
-                subprocess.run(
-                    build_show_cmd(self.right_commit),
-                    stdout=right_diff_path,
-                )
+                run_show(self.right_commit, right_diff_path)
 
             cmd = ["diff", "-y", f"-W{self.width}", "-t", left_diff_path.name, right_diff_path.name]
 


### PR DESCRIPTION
This fixes two issues @dinhngtu ran into when using `git-review-rebase` on the edk2 source code base.

While at it, I've added a new pattern for matching upstream commit that is used by kernel LTS maintainers.