### PR TITLE
docs: document commit match icons and patchid in README

### DIFF
--- a/scripts/git-review-rebase/README.md
+++ b/scripts/git-review-rebase/README.md
@@ -19,7 +19,7 @@ An interactive TUI (Terminal User Interface) tool for reviewing rebased git bran
   | Icon | Meaning                                   |
   | ---- | ----------------------------------------- |
   | `=`  | Same commit (identical SHA1               |
-  | `≈`  | Loose match (same title, patchid changed) |
+  | `~`  | Loose match (same title, patchid changed) |
   | `⤶`  | Already present in new upstream           |
   | `✗`  | Dropped during rebase                     |
   | `✚`  | Added in rebase                           |

--- a/scripts/git-review-rebase/src/git_review_rebase/constants.py
+++ b/scripts/git-review-rebase/src/git_review_rebase/constants.py
@@ -46,7 +46,7 @@ commit_match_info_repr = {
     ),
     CommitMatchInfoFlag.LooseMatch: CommitMatchInfo(
         CommitMatchInfoFlag.LooseMatch,
-        Text("≈", SolarizedColors.Yellow),
+        Text("~", SolarizedColors.Yellow),
         "Commit patchid has changed",
     ),
     CommitMatchInfoFlag.PresentInRebaseOnto: CommitMatchInfo(


### PR DESCRIPTION
Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>