### PR TITLE
git-review-rebase small improvements

### DIFF
--- a/.github/workflows/update-driver-submodules.yml
+++ b/.github/workflows/update-driver-submodules.yml
@@ -18,6 +18,7 @@ jobs:
           submodules: true
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Update driver submodules to origin/8.3
         id: update

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -37,7 +37,7 @@ PRODUCT="$(basename "${SRPM_REPO_PATH}/SPECS/"*.spec .spec)"
 OOT_DRIVER_IMPORT=${OOT_DRIVER_IMPORT:-}
 CODE_REPO_PATH="${CODE_REPO_PATH:-${SRPM_REPO_PATH}/../${PRODUCT/kernel/linux}/}"
 SPEC_FILE="SPECS/${PRODUCT}.spec"
-if [[ ${PRODUCT} = "kernel" || ${PRODUCT} = "qemu" ]]; then
+if [[ ${PRODUCT} = "kernel" || ${PRODUCT} = "kernel-alt" || ${PRODUCT} = "qemu" ]]; then
     RELEASE_PREFIX="v"
 elif [[ ${PRODUCT} = "xen" ]]; then
     RELEASE_PREFIX="RELEASE-"

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -24,14 +24,41 @@
 #
 #  CODE_REPO_PATH=/path/to/linux/repo SRPM_REPO_PATH=/path/kernel/srpm/repo git-import-srpm XS-8.2.1
 #
-# By default, the SRPM_REPO_PATH is the current working directory.  If no
-# CODE_REPO_PATH is given, a default path is inferred that is
-# SRPM_REPO_PATH/../(linux|xen|qemu) (depending on the product).
+# By default, the SRPM_REPO_PATH is the current working directory. It can also
+# be set using the -s command line option.
+# If no CODE_REPO_PATH is given (by setting the variable or by using the -c
+# command line option, a default path is inferred that is SRPM_REPO_PATH/../(linux|xen|qemu)
+# (depending on the product).
 
 set -o pipefail
 
 THIS_SCRIPT="$(readlink -f "$0")"
 
+function usage() {
+    echo "Usage: $(basename "${THIS_SCRIPT}") [-c CODE_REPO_PATH] [-s SRPM_REPO_PATH] REVISION"
+    exit "${1}"
+}
+
+while getopts ":c:s:h" opt; do
+	case "${opt}" in
+	c)
+        CODE_REPO_PATH="${OPTARG}"
+        ;;
+    s)
+        SRPM_REPO_PATH="${OPTARG}"
+        ;;
+    h|*)
+        if [ "${opt}" = "h" ]; then usage 0; else usage 1; fi
+        ;;
+    esac
+done
+
+shift "$((OPTIND - 1))"
+
+# Fail if no revision given
+[ ${#@} -ne 1 ] && usage 1
+
+SRPM_REPO_REVISION=${1}
 SRPM_REPO_PATH=${SRPM_REPO_PATH:-${PWD}}
 PRODUCT="$(basename "${SRPM_REPO_PATH}/SPECS/"*.spec .spec)"
 OOT_DRIVER_IMPORT=${OOT_DRIVER_IMPORT:-}
@@ -388,8 +415,6 @@ if [[ "$1" = "--all" ]]; then
     import_all_branches
     exit 0
 fi
-
-SRPM_REPO_REVISION=$1
 
 TMPDIR=$(mktemp -d -t src-import-xen-XXX)
 trap 'LAST_LINE=$LINENO' DEBUG


### PR DESCRIPTION
This change adds support for the kernel-alt SRPM in `git-review-rebase`. This will be helpful to manage the kernel-alt patchqueue in a kernel sources repo.

This [kernel-alt PR](https://github.com/xcp-ng-rpms/kernel-alt/pull/31) is required to be able to generate the patchqueue using `git-import-srpm`.

This also adds command line options support to pass `CODE_REPO_PATH` and `SRPM_REPO_PATH` variable values to the script.
