### PR TITLE
git-import-srpm: Add support for edk2

### DIFF
--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -55,7 +55,7 @@ while getopts ":c:s:fh" opt; do
         ;;
     esac
 done
-
+set -x
 shift "$((OPTIND - 1))"
 
 # Fail if no revision given
@@ -517,7 +517,7 @@ rpmbuild --nodeps \
          --define "_default_patch_fuzz 2" \
          "${RPM_OPTS[@]}" \
          --eval "%{_default_patch_fuzz}" \
-         -bp "${SRPM_REPO_WORKTREE}/${SPEC_FILE}" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" &
+         -bp "${SRPM_REPO_WORKTREE}/${SPEC_FILE}" |& sed 's/^/(rpmbuild)/' >> "${COMMAND_LOGS}"  &
 RPMBUILD_PID=$!
 
 if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -295,7 +295,7 @@ function export_author() {
     export GIT_AUTHOR_EMAIL="${GIT_COMMITTER_EMAIL}"
 }
 
-function apply_patch() {
+function apply_patch() (
     local worktree="$1"
     local patch="$2"
 
@@ -361,7 +361,7 @@ function apply_patch() {
         return $?
     fi
     return 0
-}
+)
 
 function apply_spec_quirks() {
     # This one is no-where to be found, and it doesn't really change any
@@ -472,7 +472,7 @@ RPMBUILD_PID=$!
 if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
     cd "${SRPM_REPO_WORKTREE}"
 
-    git show "HEAD:${SPEC_FILE}" | while IFS= read -r l; do
+    while IFS= read -r l; do
         case "${l}" in
         Patch*)
             p="${l#* }"
@@ -481,15 +481,15 @@ if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
                 if [[ -z "${CARRY_ON:-}" ]]; then
                     exit 1
                 else
-                    git am --abort || :
-                    git reset --hard || :
+                    git -C "${CODE_REPO_WORKTREE}" am --abort || :
+                    git -C "${CODE_REPO_WORKTREE}" reset --hard || :
                 fi
             }
             ;;
         *)
             ;;
         esac
-    done
+    done < <(git -C "${SRPM_REPO_WORKTREE}" show "HEAD:${SPEC_FILE}")
 fi
 
 wait "${RPMBUILD_PID}" || {

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -80,6 +80,12 @@ elif [[ ${PRODUCT} = "xen" ]]; then
 elif [[ ${PRODUCT} = "rpm" ]]; then
     RELEASE_PREFIX="rpm-"
     RELEASE_SUFFIX="-release"
+elif [[ ${PRODUCT} = "edk2" ]]; then
+    # edk2's source version (e.g. 20220801) does not match its git stable
+    # tag (e.g. edk2-stable202208).  The spec carries the exact source ref
+    # in package_srccommit, so use that when creating the source worktree.
+    RELEASE_PREFIX=""
+    RELEASE_SUFFIX=""
 else
     if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
         echo "Unknown package: '${PRODUCT}'"
@@ -149,6 +155,27 @@ function get_base_version() {
     git -C "${worktree}" show "${revision}:${SPEC_FILE}" | rpmspec -P "${RPM_OPTS[@]}" /dev/stdin | awk "/^Version:/{print \"${RELEASE_PREFIX}\" \$NF \"${RELEASE_SUFFIX:-}\"}"
 }
 
+function get_source_commit() {
+    local worktree="$1"
+    local revision="$2"
+
+    check_spec_file "${worktree}" "${revision}"
+
+    if [[ ${PRODUCT} = "edk2" ]]; then
+        local source_commit
+        source_commit=$(git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
+            awk '$1 == "%global" && $2 == "package_srccommit" { print $3; exit }'
+        )
+        if [[ -z ${source_commit} ]]; then
+            echo "${SPEC_FILE} does not define package_srccommit" 1>&2
+            exit 1
+        fi
+        echo "${source_commit}"
+    else
+        get_base_version "${worktree}" "${revision}"
+    fi
+}
+
 function get_release() {
     local worktree="$1"
     local revision="$2"
@@ -211,7 +238,7 @@ function init_worktrees() {
     # Upstream stable base
     local base_version
     if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
-        base_version=$(get_base_version "${srpm_repo_worktree}" HEAD)
+        base_version=$(get_source_commit "${srpm_repo_worktree}" HEAD)
         if [[ ${PRODUCT} = "xen" ]]; then
             if [[ ${base_version} = "RELEASE-4.13.0" ]]; then
                 base_version=85e1424de2dda
@@ -295,6 +322,67 @@ function export_author() {
     export GIT_AUTHOR_EMAIL="${GIT_COMMITTER_EMAIL}"
 }
 
+# RPM patches for edk2 can contain changes to a submodule.  Such changes
+# cannot be applied with git-am in the parent repository because it stores
+# the submodule as a gitlink rather than as ordinary files.  Reconstruct the
+# parent commit by updating that gitlink to the commit named by the patch.
+function apply_edk2_submodule_patch() {
+    local worktree="$1"
+    local patch="$2"
+    local submodule_path
+    local patch_path
+    local target_commit
+    local mailinfo
+    local subject
+
+    # Find the gitlink containing the first path in the patch by walking up
+    # its path components.
+    patch_path=$(sed -n 's@^diff --git a/\([^ ]*\) b/.*@\1@p' "${patch}" | awk 'NR == 1')
+    submodule_path="${patch_path}"
+    while [[ -n ${submodule_path} ]]; do
+        if git -C "${worktree}" ls-tree HEAD "${submodule_path}" | grep -q '^160000 '; then
+            break
+        fi
+        [[ ${submodule_path} = */* ]] || submodule_path=""
+        submodule_path="${submodule_path%/*}"
+    done
+
+    if [[ -z ${submodule_path} ]]; then
+        return 1
+    fi
+
+    # Only handle patches wholly contained in one submodule.  Mixed patches
+    # must continue through the normal parent-repository patch logic.
+    while IFS= read -r patch_path; do
+        if [[ ${patch_path} != "${submodule_path}"/* ]]; then
+            return 1
+        fi
+    done < <(sed -n 's@^diff --git a/\([^ ]*\) b/.*@\1@p' "${patch}")
+
+    # The final cherry-picked commit is the submodule commit represented by
+    # the patch's file changes.
+    target_commit=$(sed -n 's/^(cherry picked from commit \([0-9a-f]*\)).*/\1/p' "${patch}" | awk 'END {print}')
+    if [[ -z ${target_commit} ]]; then
+        return 1
+    fi
+
+    export_author
+
+    # Preserve the patch author, date, and subject for the parent commit.
+    mailinfo=$(git mailinfo /dev/null /dev/null < "${patch}" | \
+        sed -n -e 's/^Author: \(.*\)$/export GIT_AUTHOR_NAME="\1"/p' \
+               -e 's/^Email: \(.*\)$/export GIT_AUTHOR_EMAIL="\1"/p' \
+               -e 's/^Date: \(.*\)$/export GIT_AUTHOR_DATE="\1"/p' \
+               -e 's/^Subject: \(.*\)$/subject="\1"/p')
+    eval "${mailinfo}"
+    subject=${subject:-$(basename "${patch}")}
+
+    # Record a submodule update as a gitlink change in the parent repository.
+    git -C "${worktree}" update-index --add \
+        --cacheinfo "160000,${target_commit},${submodule_path}"
+    git -C "${worktree}" commit ${GIT_COMMIT_OPTIONS} -m "${subject}"
+}
+
 function apply_patch() (
     local worktree="$1"
     local patch="$2"
@@ -311,6 +399,11 @@ function apply_patch() (
     fi
 
     export_author
+
+    # git-am cannot apply a file patch to an edk2 submodule gitlink.
+    if [[ ${PRODUCT} = "edk2" ]] && apply_edk2_submodule_patch "${worktree}" "${patch}"; then
+        return 0
+    fi
 
     fixup_date "${patch}"
 

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -182,7 +182,9 @@ function get_release() {
 
     check_spec_file "${worktree}" "${revision}"
 
-    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | rpmspec -P "${RPM_OPTS[@]}" /dev/stdin | awk '/^Release:/{print $NF}'
+    git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
+        rpmspec -P "${RPM_OPTS[@]}" --define 'dist %{nil}' /dev/stdin | \
+        awk '/^Release:/{print $NF}'
 }
 
 function get_full_version() {

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -230,6 +230,22 @@ function get_branch_name() {
     fi
 }
 
+function edk2_fixup_submodules() {
+    # The actual state of the sub-modules might differ from the
+    # tarballs released with the tarballs when compared with the
+    # upstream version of the package, so make sure to fix this up
+    openssl_version=$(sed -n 's/Source[0-9]\+: openssl-\([0-9.]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+    git -C "${code_repo_worktree}"/CryptoPkg/Library/OpensslLib/openssl checkout openssl-"${openssl_version}"
+    brotli_basetools_sha1=$(sed -n 's/Source[0-9]\+: brotli-basetools-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+    git -C "${code_repo_worktree}"/BaseTools/Source/C/BrotliCompress/brotli checkout "${brotli_basetools_sha1}"
+    brotli_lib_sha1=$(sed -n 's/Source[0-9]\+: brotli-lib-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+    git -C "${code_repo_worktree}"/MdeModulePkg/Library/BrotliCustomDecompressLib/brotli checkout "${brotli_lib_sha1}"
+
+    export_author
+
+    git -C "${code_repo_worktree}" commit --all ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "Update sub-modules to matching package version."
+}
+
 function init_worktrees() {
     local srpm_repo_worktree="$1"
     local code_repo_worktree="$2"
@@ -269,6 +285,10 @@ function init_worktrees() {
     }
 
     git -C "${CODE_REPO_PATH}" worktree add -B "${BRANCH_NAME}-partial" "${code_repo_worktree}" "${base_version}" >> "${COMMAND_LOGS}"
+    git -C ${code_repo_worktree} submodule update --init
+    if [[ ${PRODUCT} == "edk2" ]]; then
+        edk2_fixup_submodules
+    fi
     git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%patched}source" "${base_version}"
 }
 
@@ -324,67 +344,6 @@ function export_author() {
     export GIT_AUTHOR_EMAIL="${GIT_COMMITTER_EMAIL}"
 }
 
-# RPM patches for edk2 can contain changes to a submodule.  Such changes
-# cannot be applied with git-am in the parent repository because it stores
-# the submodule as a gitlink rather than as ordinary files.  Reconstruct the
-# parent commit by updating that gitlink to the commit named by the patch.
-function apply_edk2_submodule_patch() {
-    local worktree="$1"
-    local patch="$2"
-    local submodule_path
-    local patch_path
-    local target_commit
-    local mailinfo
-    local subject
-
-    # Find the gitlink containing the first path in the patch by walking up
-    # its path components.
-    patch_path=$(sed -n 's@^diff --git a/\([^ ]*\) b/.*@\1@p' "${patch}" | awk 'NR == 1')
-    submodule_path="${patch_path}"
-    while [[ -n ${submodule_path} ]]; do
-        if git -C "${worktree}" ls-tree HEAD "${submodule_path}" | grep -q '^160000 '; then
-            break
-        fi
-        [[ ${submodule_path} = */* ]] || submodule_path=""
-        submodule_path="${submodule_path%/*}"
-    done
-
-    if [[ -z ${submodule_path} ]]; then
-        return 1
-    fi
-
-    # Only handle patches wholly contained in one submodule.  Mixed patches
-    # must continue through the normal parent-repository patch logic.
-    while IFS= read -r patch_path; do
-        if [[ ${patch_path} != "${submodule_path}"/* ]]; then
-            return 1
-        fi
-    done < <(sed -n 's@^diff --git a/\([^ ]*\) b/.*@\1@p' "${patch}")
-
-    # The final cherry-picked commit is the submodule commit represented by
-    # the patch's file changes.
-    target_commit=$(sed -n 's/^(cherry picked from commit \([0-9a-f]*\)).*/\1/p' "${patch}" | awk 'END {print}')
-    if [[ -z ${target_commit} ]]; then
-        return 1
-    fi
-
-    export_author
-
-    # Preserve the patch author, date, and subject for the parent commit.
-    mailinfo=$(git mailinfo /dev/null /dev/null < "${patch}" | \
-        sed -n -e 's/^Author: \(.*\)$/export GIT_AUTHOR_NAME="\1"/p' \
-               -e 's/^Email: \(.*\)$/export GIT_AUTHOR_EMAIL="\1"/p' \
-               -e 's/^Date: \(.*\)$/export GIT_AUTHOR_DATE="\1"/p' \
-               -e 's/^Subject: \(.*\)$/subject="\1"/p')
-    eval "${mailinfo}"
-    subject=${subject:-$(basename "${patch}")}
-
-    # Record a submodule update as a gitlink change in the parent repository.
-    git -C "${worktree}" update-index --add \
-        --cacheinfo "160000,${target_commit},${submodule_path}"
-    git -C "${worktree}" commit ${GIT_COMMIT_OPTIONS} -m "${subject}"
-}
-
 function apply_patch() (
     local worktree="$1"
     local patch="$2"
@@ -401,11 +360,6 @@ function apply_patch() (
     fi
 
     export_author
-
-    # git-am cannot apply a file patch to an edk2 submodule gitlink.
-    if [[ ${PRODUCT} = "edk2" ]] && apply_edk2_submodule_patch "${worktree}" "${patch}"; then
-        return 0
-    fi
 
     fixup_date "${patch}"
 
@@ -448,10 +402,12 @@ function apply_patch() (
             fi
 
             # There was a commit description, so try and use it
-            git commit ${GIT_COMMIT_OPTIONS} -F "${git_dir}"/rebase-apply/msg && git am --skip
+            git submodule foreach "git commit -a ${GIT_COMMIT_OPTIONS} -F ${git_dir}/rebase-apply/msg || :" || :
+            git commit -a ${GIT_COMMIT_OPTIONS} -F "${git_dir}"/rebase-apply/msg && git am --skip
         else
             # No commit description, use the patch path
-            git commit ${GIT_COMMIT_OPTIONS} -m "$(basename "${p}")" && git am --skip
+            git submodule foreach "git commit -a ${GIT_COMMIT_OPTIONS} -m \"$(basename "${p}")\" || :" || :
+            git commit -a ${GIT_COMMIT_OPTIONS} -m "$(basename "${p}")" && git am --skip
         fi
         return $?
     fi
@@ -592,14 +548,18 @@ wait "${RPMBUILD_PID}" || {
     exit 1
 } && {
     build_dir="$(get_build_dir "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
-    git -C "${CODE_REPO_WORKTREE}" --work-tree "${build_dir}" add -A
-    export_author
 
     if [[ -z "${OOT_DRIVER_IMPORT}" ]]; then
         commit_msg="rpmbuild: remaining diff."
     else
         commit_msg="git-import-srpm: import of $(get_full_version "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
     fi
+
+    git -C "${CODE_REPO_WORKTREE}" submodule foreach "git --work-tree ${build_dir}/\${sm_path} add -A"
+    git -C "${CODE_REPO_WORKTREE}" --work-tree "${build_dir}" add -A
+    export_author
+
+    git -C "${CODE_REPO_WORKTREE}" submodule foreach "git commit ${GIT_COMMIT_OPTIONS} -s --date=\"${GIT_COMMITTER_DATE}\" -m \"${commit_msg}\" || :" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}"
     git -C "${CODE_REPO_WORKTREE}" commit ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "${commit_msg}" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" || :
 }
 

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -230,21 +230,53 @@ function get_branch_name() {
     fi
 }
 
-function edk2_fixup_submodules() {
+function del_submodule() {
+    local submodule="$1"
+
+    # remove submodule from the index but leave its files in the tree
+    git rm --cached "$submodule"
+    git commit -s --date="${GIT_COMMITTER_DATE}" -m "$submodule: removed."
+
+    rm "$submodule"/.git
+ }
+
+function flatten_submodule() {
+    local submodule="$1"
+    local ref="$2"
+
+    # Checkout right rev and commit
+    (
+        cd "$submodule"
+        git checkout "$2"
+    )
+    git commit -a -s --date="${GIT_COMMITTER_DATE}" -m "$submodule: update to matching package version." || :
+
+    # Remove sub-module from git's knowledge
+    del_submodule "$submodule"
+
+    # Commit all files within as regular files
+    git add "$submodule"
+    git commit -s --date="${GIT_COMMITTER_DATE}" -m "$submodule: flatten into parent repo."
+}
+
+function edk2_fixup_submodules() (
     # The actual state of the sub-modules might differ from the
     # tarballs released with the tarballs when compared with the
     # upstream version of the package, so make sure to fix this up
-    openssl_version=$(sed -n 's/Source[0-9]\+: openssl-\([0-9.]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
-    git -C "${code_repo_worktree}"/CryptoPkg/Library/OpensslLib/openssl checkout openssl-"${openssl_version}"
-    brotli_basetools_sha1=$(sed -n 's/Source[0-9]\+: brotli-basetools-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
-    git -C "${code_repo_worktree}"/BaseTools/Source/C/BrotliCompress/brotli checkout "${brotli_basetools_sha1}"
-    brotli_lib_sha1=$(sed -n 's/Source[0-9]\+: brotli-lib-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
-    git -C "${code_repo_worktree}"/MdeModulePkg/Library/BrotliCustomDecompressLib/brotli checkout "${brotli_lib_sha1}"
+
+    cd "${code_repo_worktree}"
 
     export_author
 
-    git -C "${code_repo_worktree}" commit --all ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "Update sub-modules to matching package version."
-}
+    openssl_version=$(sed -n 's/Source[0-9]\+: openssl-\([0-9.]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+    flatten_submodule CryptoPkg/Library/OpensslLib/openssl openssl-"${openssl_version}"
+
+    brotli_basetools_sha1=$(sed -n 's/Source[0-9]\+: brotli-basetools-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+    flatten_submodule BaseTools/Source/C/BrotliCompress/brotli "${brotli_basetools_sha1}"
+
+    brotli_lib_sha1=$(sed -n 's/Source[0-9]\+: brotli-lib-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+    flatten_submodule MdeModulePkg/Library/BrotliCustomDecompressLib/brotli  "${brotli_lib_sha1}"
+)
 
 function init_worktrees() {
     local srpm_repo_worktree="$1"
@@ -285,8 +317,8 @@ function init_worktrees() {
     }
 
     git -C "${CODE_REPO_PATH}" worktree add -B "${BRANCH_NAME}-partial" "${code_repo_worktree}" "${base_version}" >> "${COMMAND_LOGS}"
-    git -C ${code_repo_worktree} submodule update --init
     if [[ ${PRODUCT} == "edk2" ]]; then
+	git -C ${code_repo_worktree} submodule update --init
         edk2_fixup_submodules
     fi
     git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%patched}source" "${base_version}"
@@ -401,12 +433,8 @@ function apply_patch() (
                 export GIT_AUTHOR_EMAIL="<berrange@redhat.com>"
             fi
 
-            # There was a commit description, so try and use it
-            git submodule foreach "git commit -a ${GIT_COMMIT_OPTIONS} -F ${git_dir}/rebase-apply/msg || :" || :
             git commit -a ${GIT_COMMIT_OPTIONS} -F "${git_dir}"/rebase-apply/msg && git am --skip
         else
-            # No commit description, use the patch path
-            git submodule foreach "git commit -a ${GIT_COMMIT_OPTIONS} -m \"$(basename "${p}")\" || :" || :
             git commit -a ${GIT_COMMIT_OPTIONS} -m "$(basename "${p}")" && git am --skip
         fi
         return $?
@@ -555,11 +583,8 @@ wait "${RPMBUILD_PID}" || {
         commit_msg="git-import-srpm: import of $(get_full_version "${SRPM_REPO_WORKTREE}" "${SRPM_REPO_REVISION}")"
     fi
 
-    git -C "${CODE_REPO_WORKTREE}" submodule foreach "git --work-tree ${build_dir}/\${sm_path} add -A"
     git -C "${CODE_REPO_WORKTREE}" --work-tree "${build_dir}" add -A
     export_author
-
-    git -C "${CODE_REPO_WORKTREE}" submodule foreach "git commit ${GIT_COMMIT_OPTIONS} -s --date=\"${GIT_COMMITTER_DATE}\" -m \"${commit_msg}\" || :" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}"
     git -C "${CODE_REPO_WORKTREE}" commit ${GIT_COMMIT_OPTIONS} -s --date="${GIT_COMMITTER_DATE}" -m "${commit_msg}" 2>> "${COMMAND_LOGS}" >> "${COMMAND_LOGS}" || :
 }
 

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -242,7 +242,6 @@ function del_submodule() {
 
 function flatten_submodule() {
     local submodule="$1"
-    local ref="$2"
 
     # Checkout right rev and commit
     (
@@ -318,7 +317,7 @@ function init_worktrees() {
 
     git -C "${CODE_REPO_PATH}" worktree add -B "${BRANCH_NAME}-partial" "${code_repo_worktree}" "${base_version}" >> "${COMMAND_LOGS}"
     if [[ ${PRODUCT} == "edk2" ]]; then
-	git -C ${code_repo_worktree} submodule update --init
+	git -C "${code_repo_worktree}" submodule update --init
         edk2_fixup_submodules
     fi
     git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%patched}source" "${base_version}"

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -434,7 +434,7 @@ function apply_patch() (
 
             git commit -a ${GIT_COMMIT_OPTIONS} -F "${git_dir}"/rebase-apply/msg && git am --skip
         else
-            git commit -a ${GIT_COMMIT_OPTIONS} -m "$(basename "${p}")" && git am --skip
+            git commit -a ${GIT_COMMIT_OPTIONS} -m "$(basename "${p}" .patch)" && git am --skip
         fi
         return $?
     fi


### PR DESCRIPTION
The edk2 package comes with some oddities:

* The upstream version cannot be easily inferred from the Version:
  directive, but must be taken from %package_srccommit instead;
* Upstream uses submodules quite extensively, so the package must vendor
  many of these dependencies in tarballs. It also carries patches on
  these dependencies, and applying them is not trivial.

Add specific rules for the package, as well as a dedicated function
apply_edk2_submodule_patch to deal with submodule patches.

Also add a fix to remove the dist suffix (e.g. ".fc44" if run on FC44) in imported branch names.