### PR TITLE
Support importing older versions of edk2 with git-import-srpm.

### DIFF
--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -306,7 +306,7 @@ function init_worktrees() {
         if [[ "${FORCE_IMPORT:-}" ]]; then
             git -C "${CODE_REPO_PATH}" branch -D "${BRANCH_NAME}"
         else
-            exit 1
+            exit 0
         fi
     fi
 

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -170,6 +170,11 @@ function get_source_commit() {
             awk '$1 == "%global" && $2 == "package_srccommit" { print $3; exit }'
         )
         if [[ -z ${source_commit} ]]; then
+            source_commit=$(git -C "${worktree}" show "${revision}:${SPEC_FILE}" | \
+                awk '$1 == "%global" && $2 == "edk2_githash" { print $3; exit }'
+            )
+        fi
+        if [[ -z ${source_commit} ]]; then
             echo "${SPEC_FILE} does not define package_srccommit" 1>&2
             exit 1
         fi
@@ -270,14 +275,33 @@ function edk2_fixup_submodules() (
 
     export_author
 
-    openssl_version=$(sed -n 's/Source[0-9]\+: openssl-\([0-9.]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
-    flatten_submodule CryptoPkg/Library/OpensslLib/openssl openssl-"${openssl_version}"
+    if grep --quiet 'Source[0-9]\+: openssl-.*.tar.gz' "${srpm_repo_worktree}/${SPEC_FILE}"; then
+        openssl_version=openssl-$(sed -n 's/Source[0-9]\+: openssl-\([0-9.]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+        if [ "${openssl_version}" = "openssl-" ]; then
+            openssl_version=$(sed -n 's/Source[0-9]\+: openssl-\([0-9a-f]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+        fi
+    else
+        openssl_version=HEAD
+    fi
+    flatten_submodule CryptoPkg/Library/OpensslLib/openssl "${openssl_version}"
 
-    brotli_basetools_sha1=$(sed -n 's/Source[0-9]\+: brotli-basetools-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
-    flatten_submodule BaseTools/Source/C/BrotliCompress/brotli "${brotli_basetools_sha1}"
+    if [ -d BaseTools/Source/C/BrotliCompress/brotli ]; then
+        if grep --quiet 'Source[0-9]\+: brotli-basetools-.*.tar.gz'  "${srpm_repo_worktree}/${SPEC_FILE}"; then
+            brotli_basetools_sha1=$(sed -n 's/Source[0-9]\+: brotli-basetools-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+        else
+            brotli_basetools_sha1=HEAD
+        fi
+        flatten_submodule BaseTools/Source/C/BrotliCompress/brotli "${brotli_basetools_sha1}"
+    fi
 
-    brotli_lib_sha1=$(sed -n 's/Source[0-9]\+: brotli-lib-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
-    flatten_submodule MdeModulePkg/Library/BrotliCustomDecompressLib/brotli  "${brotli_lib_sha1}"
+    if [ -d MdeModulePkg/Library/BrotliCustomDecompressLib/brotli ]; then
+        if grep --quiet 'Source[0-9]\+: brotli-lib-.*.tar.gz' "${srpm_repo_worktree}/${SPEC_FILE}"; then
+            brotli_lib_sha1=$(sed -n 's/Source[0-9]\+: brotli-lib-\([0-9a-z]\+\)\.tar.gz/\1/p' "${srpm_repo_worktree}/${SPEC_FILE}")
+        else
+            brotli_lib_sha1=HEAD
+        fi
+        flatten_submodule MdeModulePkg/Library/BrotliCustomDecompressLib/brotli  "${brotli_lib_sha1}"
+    fi
 )
 
 function init_worktrees() {

--- a/scripts/git-import-srpm
+++ b/scripts/git-import-srpm
@@ -5,7 +5,7 @@
 #     git-import-srpm HEAD
 #
 # - To import all revisions (the script will dedupe the branches):
-#     git-import-srpm --all
+#     git-import-srpm -a
 #
 # This is a poor man's script importing a SRPM into a git repository.  It
 # has a few limitations in its current quick&dirty implementation:
@@ -39,8 +39,11 @@ function usage() {
     exit "${1}"
 }
 
-while getopts ":c:s:fh" opt; do
+while getopts ":ac:s:fh" opt; do
     case "${opt}" in
+    a)
+        IMPORT_ALL=true
+        ;;
     c)
         CODE_REPO_PATH="$(realpath "${OPTARG}")"
         ;;
@@ -59,9 +62,9 @@ set -x
 shift "$((OPTIND - 1))"
 
 # Fail if no revision given
-[ ${#@} -ne 1 ] && usage 1
+[ -z "${IMPORT_ALL:-}" ] && [ ${#@} -ne 1 ] && usage 1
 
-SRPM_REPO_REVISION=${1}
+SRPM_REPO_REVISION=${1:-}
 SRPM_REPO_PATH=${SRPM_REPO_PATH:-${PWD}}
 PRODUCT="$(basename "${SRPM_REPO_PATH}/SPECS/"*.spec .spec)"
 SPEC_FILE="SPECS/${PRODUCT}.spec"
@@ -317,7 +320,7 @@ function init_worktrees() {
 
     git -C "${CODE_REPO_PATH}" worktree add -B "${BRANCH_NAME}-partial" "${code_repo_worktree}" "${base_version}" >> "${COMMAND_LOGS}"
     if [[ ${PRODUCT} == "edk2" ]]; then
-	git -C "${code_repo_worktree}" submodule update --init
+        git -C "${code_repo_worktree}" submodule update --init
         edk2_fixup_submodules
     fi
     git -C "${CODE_REPO_PATH}" branch -f "${BRANCH_NAME%patched}source" "${base_version}"
@@ -493,13 +496,13 @@ function import_all_branches() {
     done | (SRPM_REPO_PATH="${SRPM_REPO_PATH}" CODE_REPO_PATH="${CODE_REPO_PATH}" xargs -n 1 -P "${nproc}" "${THIS_SCRIPT}")
 }
 
-COMMAND_LOGS=/tmp/git-import-srpm.${PRODUCT}.${1}.debug.log
+COMMAND_LOGS=/tmp/git-import-srpm.${PRODUCT}.${1:-all}.debug.log
 if [[ -f ${COMMAND_LOGS} ]]; then
     rm "${COMMAND_LOGS}"
 fi
 exec 2> "${COMMAND_LOGS}"
 
-if [[ "$1" = "--all" ]]; then
+if [[ "${IMPORT_ALL:-}" ]]; then
     import_all_branches
     exit 0
 fi


### PR DESCRIPTION
Recent support for importing edk2 rpm into source branches lacked support for importing older versions.

While at it, fix a couple of bugs that were introduced recently.